### PR TITLE
docs(readme): highlight Windows per-user MSI (no admin) and clarify install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _Coming Soon: Demo screenshot showing the beautiful interface_
 
 | Platform | Architecture          | File                                   | Direct Download                                                                                                                       |
 | -------- | --------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Windows  | x64                   | MSI Installer (Per-user, no admin req) | [BoxdBuddies_1.0.0_x64_en-US.msi](https://github.com/Wootehfook/BoxdBuddies/releases/download/v1.0.0/BoxdBuddies_1.0.0_x64_en-US.msi) |
+| Windows  | x64                   | MSI Installer (Per-user, no admin required) | [BoxdBuddies_1.0.0_x64_en-US.msi](https://github.com/Wootehfook/BoxdBuddies/releases/download/v1.0.0/BoxdBuddies_1.0.0_x64_en-US.msi) |
 | macOS    | Apple Silicon (ARM64) | DMG                                    | [BoxdBuddies_1.0.0_aarch64.dmg](https://github.com/Wootehfook/BoxdBuddies/releases/download/v1.0.0/BoxdBuddies_1.0.0_aarch64.dmg)     |
 | Linux    | x86_64                | DEB / AppImage                         | [See release page for .deb and .AppImage downloads](https://github.com/Wootehfook/BoxdBuddies/releases/tag/v1.0.0)                    |
 | All      | N/A                   | Checksums                              | [CHECKSUMS.txt](https://github.com/Wootehfook/BoxdBuddies/releases/download/v1.0.0/CHECKSUMS.txt)                                     |

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ _Coming Soon: Demo screenshot showing the beautiful interface_
 
 ## 📥 Downloads (v1.0.0)
 
-| Platform | Architecture          | File           | Direct Download                                                                                                                       |
-| -------- | --------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Windows  | x64                   | MSI Installer  | [BoxdBuddies_1.0.0_x64_en-US.msi](https://github.com/Wootehfook/BoxdBuddies/releases/download/v1.0.0/BoxdBuddies_1.0.0_x64_en-US.msi) |
-| macOS    | Apple Silicon (ARM64) | DMG            | [BoxdBuddies_1.0.0_aarch64.dmg](https://github.com/Wootehfook/BoxdBuddies/releases/download/v1.0.0/BoxdBuddies_1.0.0_aarch64.dmg)     |
-| Linux    | x86_64                | DEB / AppImage | [See release page for .deb and .AppImage downloads](https://github.com/Wootehfook/BoxdBuddies/releases/tag/v1.0.0)                    |
-| All      | N/A                   | Checksums      | [CHECKSUMS.txt](https://github.com/Wootehfook/BoxdBuddies/releases/download/v1.0.0/CHECKSUMS.txt)                                     |
+| Platform | Architecture          | File                                   | Direct Download                                                                                                                       |
+| -------- | --------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Windows  | x64                   | MSI Installer (Per-user, no admin req) | [BoxdBuddies_1.0.0_x64_en-US.msi](https://github.com/Wootehfook/BoxdBuddies/releases/download/v1.0.0/BoxdBuddies_1.0.0_x64_en-US.msi) |
+| macOS    | Apple Silicon (ARM64) | DMG                                    | [BoxdBuddies_1.0.0_aarch64.dmg](https://github.com/Wootehfook/BoxdBuddies/releases/download/v1.0.0/BoxdBuddies_1.0.0_aarch64.dmg)     |
+| Linux    | x86_64                | DEB / AppImage                         | [See release page for .deb and .AppImage downloads](https://github.com/Wootehfook/BoxdBuddies/releases/tag/v1.0.0)                    |
+| All      | N/A                   | Checksums                              | [CHECKSUMS.txt](https://github.com/Wootehfook/BoxdBuddies/releases/download/v1.0.0/CHECKSUMS.txt)                                     |
 
 ### 🔐 Integrity Verification
 
@@ -35,6 +35,8 @@ _Coming Soon: Demo screenshot showing the beautiful interface_
 3. Ensure reported hashes are `OK`.
 
 If a file is missing from CHECKSUMS, re-download directly from the release page.
+
+Note: The Windows installer is a per-user MSI that installs under your user profile (LocalAppData) and does not require administrative privileges.
 
 ### ✅ Recent Achievements (August 3, 2025)
 


### PR DESCRIPTION
This PR updates the README to make the Windows per-user MSI more visible on GitHub:

- Label the Windows installer as “Per-user, no admin required”
- Add a clarifying note that it installs under LocalAppData

No code changes; documentation only.