### PR TITLE
docs & ci: per-user MSI details, GPG-signed checksums, ARP metadata, smoke tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,21 @@ jobs:
           $value = $record.GetType().InvokeMember('StringData',[System.Reflection.BindingFlags]::GetProperty,$null,$record,1)
           if ($value -ne '2') { Write-Error "Expected ALLUSERS=2 for per-user MSI, found '$value'"; exit 1 } else { Write-Host 'Per-user verified (ALLUSERS=2).' }
 
+      - name: Silent install/uninstall smoke test (Windows MSI)
+        shell: pwsh
+        run: |
+          $msi = Get-ChildItem -Path src-tauri/target/release/bundle/msi -Filter *.msi -Recurse | Select-Object -First 1
+          if (-not $msi) { Write-Error 'MSI not found for smoke test'; exit 1 }
+          Write-Host "Silent installing $($msi.FullName)"
+          $log = Join-Path $env:RUNNER_TEMP 'msi-install.log'
+          Start-Process msiexec.exe -ArgumentList @('/i', '"' + $msi.FullName + '"', '/qn', '/norestart', '/L*v', '"' + $log + '"') -Wait -NoNewWindow
+          if (-not (Test-Path "$env:LOCALAPPDATA\BoxdBuddies")) { Write-Error 'Install directory missing after silent install.'; exit 1 }
+          Write-Host 'Silent install succeeded; performing uninstall.'
+          Start-Process msiexec.exe -ArgumentList @('/x', '"' + $msi.FullName + '"', '/qn', '/norestart') -Wait -NoNewWindow
+            Start-Sleep -Seconds 2
+          if (Test-Path "$env:LOCALAPPDATA\BoxdBuddies") { Write-Error 'Install directory still exists after uninstall.'; exit 1 }
+          Write-Host 'Silent install/uninstall verification passed.'
+
       - name: sccache stats (Windows)
         # AI Generated: GitHub Copilot - 2025-08-08
         run: sccache --show-stats || echo "sccache not available"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,6 +338,19 @@ jobs:
             exit 1
           fi
 
+      - name: Sign checksums (GPG detached signature)
+        if: ${{ secrets.GPG_PRIVATE_KEY != '' && secrets.GPG_PASSPHRASE != '' }}
+        run: |
+          set -e
+          echo "Importing GPG key for checksum signing";
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --import
+          gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --detach-sign --armor -o CHECKSUMS.txt.asc CHECKSUMS.txt
+          echo "Signature generated: CHECKSUMS.txt.asc";
+          gpg --list-keys || true
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
@@ -348,6 +361,7 @@ jobs:
             linux-packages/*.deb
             linux-packages/*.AppImage
             CHECKSUMS.txt
+            CHECKSUMS.txt.asc
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/.github/workflows/windows-peruser-msi-test.yml
+++ b/.github/workflows/windows-peruser-msi-test.yml
@@ -135,6 +135,20 @@ jobs:
           }
           Write-Error "Unexpected ALLUSERS value '$value'. Expected '2' (per-user) or property to be absent."; exit 1
 
+      - name: Silent install & uninstall smoke test
+        shell: pwsh
+        run: |
+          $msiPath = '${{ steps.find_msi.outputs.msi_path }}'
+          Write-Host "Starting silent install: $msiPath"
+          $installLog = Join-Path $env:RUNNER_TEMP 'install.log'
+          Start-Process msiexec.exe -ArgumentList @('/i', '"' + $msiPath + '"', '/qn', '/norestart', '/L*v', '"' + $installLog + '"') -Wait -NoNewWindow
+          if (-not (Test-Path "$env:LOCALAPPDATA\BoxdBuddies")) { Write-Error 'Install directory not found after silent install.'; exit 1 }
+          Write-Host 'Silent install completed. Beginning silent uninstall.'
+          Start-Process msiexec.exe -ArgumentList @('/x', '"' + $msiPath + '"', '/qn', '/norestart') -Wait -NoNewWindow
+          Start-Sleep -Seconds 2
+          if (Test-Path "$env:LOCALAPPDATA\BoxdBuddies") { Write-Error 'Install directory still present after uninstall.'; exit 1 }
+          Write-Host 'Silent install/uninstall smoke test passed.'
+
       - name: Upload MSI artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@
 
 Find movies that you and your friends all want to watch! BoxdBuddies connects to Letterboxd, compares multiple watchlists, and shows you the perfect movies for your next group watch.
 
+<!-- Demo screenshot placeholder intentionally retained; update once final UI capture ready -->
+
 ![BoxdBuddies Demo](docs/images/demo-hero.png)
-_Coming Soon: Demo screenshot showing the beautiful interface_
+_Demo image will be updated post public launch_
 
 ## 🎉 Status: Production Ready ✨
 
@@ -35,7 +37,20 @@ _Coming Soon: Demo screenshot showing the beautiful interface_
 
 If a file is missing from CHECKSUMS, re-download directly from the release page.
 
-Note: The Windows installer is a per-user MSI that installs under your user profile (LocalAppData) and does not require administrative privileges.
+Note: The Windows installer is a strict per-user MSI (ALLUSERS=2) that installs under
+`%LOCALAPPDATA%\BoxdBuddies` and does not require elevation. A future enhancement may add an
+optional “Install for all users” variant.
+
+### 🧩 Installer Details (Windows MSI)
+
+- Scope: Per-user only (no UAC prompt)
+- Uninstall: Standard Apps & Features entry or `msiexec /x BoxdBuddies_1.0.0_x64_en-US.msi`
+- Silent install: `msiexec /i BoxdBuddies_1.0.0_x64_en-US.msi /qn /norestart`
+- ARP metadata: Custom icon + project link for About info
+- Install location: `%LOCALAPPDATA%/BoxdBuddies`
+
+The build pipeline automatically validates the MSI sets `ALLUSERS=2` and performs a headless
+install/uninstall cycle to ensure integrity.
 
 ### ✅ Recent Achievements (August 3, 2025)
 
@@ -253,6 +268,25 @@ npm run tauri build
 ```
 
 The built application will be available in `src-tauri/target/release/bundle/`.
+
+### Code Signing (Optional / Recommended)
+
+Windows code signing is supported in CI when the following secrets are configured:
+
+| Secret                | Purpose                                       |
+| --------------------- | --------------------------------------------- |
+| `WIN_CERT_PFX_BASE64` | Base64-encoded PFX certificate (Authenticode) |
+| `WIN_CERT_PASSWORD`   | Password for the PFX file                     |
+
+During the release workflow the EXE and MSI are signed if both secrets are present. For local
+signing, export your certificate to a password-protected `.pfx`, then:
+
+```powershell
+signtool sign /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 /f codesign.pfx /p $env:WIN_CERT_PASSWORD path\to\BoxdBuddies.exe
+```
+
+macOS notarization & signing will be added in a future milestone. Linux packages typically do not
+require code signing; GPG-signed checksums may be added later.
 
 ### Docker Build
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ _Demo image will be updated post public launch_
    ```
 3. Ensure reported hashes are `OK`.
 
+If a `CHECKSUMS.txt.asc` file is present (GPG detached signature) you can verify authenticity:
+
+```bash
+gpg --keyserver keyserver.ubuntu.com --recv-keys <MAINTAINER_KEY_ID>
+gpg --verify CHECKSUMS.txt.asc CHECKSUMS.txt
+```
+
+You should see a valid signature from the BoxdBuddies release key. Treat signature absence as
+expected only for early pre-release artifacts.
+
 If a file is missing from CHECKSUMS, re-download directly from the release page.
 
 Note: The Windows installer is a strict per-user MSI (ALLUSERS=2) that installs under

--- a/src-tauri/wix/main.wxs
+++ b/src-tauri/wix/main.wxs
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- AI Generated: GitHub Copilot - 2025-08-08 -->
-<!-- Per-user (AllUsers="no") WiX template for BoxdBuddies to avoid requiring administrative elevation. -->
+<!-- AI Generated: GitHub Copilot - 2025-08-09 -->
+<!-- Reverted to validated per-user only WiX definition to restore candle.exe success.
+     Multi-scope (per-user/per-machine) attempt removed because Tauri's
+     default bundler invocation does not add required UI extension logic
+     for custom scope dialog without extra configuration. We'll iterate
+     on multi-scope in a follow-up once a passing baseline is re-established. -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product Id="*" Name="BoxdBuddies" Language="1033" Version="1.0.0" Manufacturer="BoxdBuddies" UpgradeCode="d4d205ab-f2d3-4e2d-9d50-1d6e3b2a8c01">
-    <!-- Per-user install: enforce limited privileges to avoid elevation prompts and scope ambiguity -->
-    <!-- AI Generated: GitHub Copilot - 2025-08-08 -->
+    <!-- Per-user install: enforce limited privileges to avoid elevation prompts -->
     <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" InstallPrivileges="limited" />
 
-  <!-- Explicitly enforce per-user context. CI validates this setting on each build. -->
-  <!-- AI Generated: GitHub Copilot - 2025-08-08 -->
-  <Property Id="ALLUSERS" Value="2" />
-  <!-- Ensure Windows Installer uses per-user context (no elevation prompts) -->
-  <Property Id="MSIINSTALLPERUSER" Value="1" />
+    <!-- Explicit per-user context (Windows Installer uses ALLUSERS=2 for pure per-user packages) -->
+    <Property Id="ALLUSERS" Value="2" />
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
     <MediaTemplate EmbedCab="yes" />
-
-  <!-- Note: ALLUSERS=2 and MSIINSTALLPERUSER=1 are set above to lock per-user installs. -->
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="LocalAppDataFolder">
@@ -25,51 +23,23 @@
     </Directory>
 
     <Feature Id="MainFeature" Title="BoxdBuddies" Level="1">
-      <!-- Reference the main executable component directly to avoid unresolved AppFiles group. -->
       <ComponentRef Id="MainExecutableComponent" />
     </Feature>
   </Product>
 
-  <!-- AI Generated: GitHub Copilot - 2025-08-07 -->
-  <!-- Provide the missing AppFiles ComponentGroup and include the built executable.
-  Tauri passes -dSourceDir=PATH\\BoxdBuddies.exe to candle; use that here. -->
   <Fragment>
-    <!-- Install our main executable into INSTALLFOLDER -->
     <DirectoryRef Id="INSTALLFOLDER">
-  <!-- IMPORTANT: Preserve this Component GUID across releases. Changing it breaks upgrades/uninstall. -->
-  <Component Id="MainExecutableComponent" Guid="7E0DAB8B-2D40-4D2B-9B3D-2B2C3E5C902F">
-        <!-- AI Generated: GitHub Copilot - 2025-08-08 -->
-        <!--
-          Per-user install compliance fixes:
-          - ICE38: Use an HKCU registry value as the KeyPath (not a file) for components
-            installing under user profile directories.
-          - ICE64: Ensure the per-user INSTALLFOLDER is cleaned up on uninstall.
-        -->
-
-        <!-- Install the main executable file into the per-user install folder -->
-        <File Id="MainExecutable"
-              Source="$(var.SourceDir)" />
-
-        <!-- Use HKCU registry value as KeyPath to satisfy ICE38 -->
+      <!-- Stable GUID preserved (was previously used for per-user component). -->
+      <Component Id="MainExecutableComponent" Guid="7E0DAB8B-2D40-4D2B-9B3D-2B2C3E5C902F">
+        <File Id="MainExecutable" Source="$(var.SourceDir)" />
+        <!-- HKCU registry key as KeyPath satisfies ICE38 for per-user profile folder install -->
         <RegistryKey Root="HKCU" Key="Software\[Manufacturer]\[ProductName]">
-          <RegistryValue Id="RegInstallDir"
-                          Name="InstallDir"
-                          Type="string"
-                          Value="[INSTALLFOLDER]"
-                          KeyPath="yes" />
+          <RegistryValue Id="RegInstallDir" Name="InstallDir" Type="string" Value="[INSTALLFOLDER]" KeyPath="yes" />
         </RegistryKey>
-
-        <!-- Uninstall cleanup to satisfy ICE64 (remove files and then folder) -->
-        <RemoveFile Id="CleanInstallFolderFiles"
-                    Name="*"
-                    On="uninstall"
-                    Directory="INSTALLFOLDER" />
-        <RemoveFolder Id="RemoveInstallFolder"
-                      On="uninstall"
-                      Directory="INSTALLFOLDER" />
+        <!-- Cleanup for ICE64 compliance -->
+        <RemoveFile Id="CleanInstallFolderFiles" Name="*" On="uninstall" Directory="INSTALLFOLDER" />
+        <RemoveFolder Id="RemoveInstallFolder" On="uninstall" Directory="INSTALLFOLDER" />
       </Component>
     </DirectoryRef>
-
-  <!-- No ComponentGroup needed; Feature references the component directly. -->
   </Fragment>
 </Wix>

--- a/src-tauri/wix/main.wxs
+++ b/src-tauri/wix/main.wxs
@@ -18,6 +18,8 @@
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
     <MediaTemplate EmbedCab="yes" />
+  <!-- Icon resource used for ARPPRODUCTICON (must be an .ico file) -->
+  <Icon Id="AppExeIcon" SourceFile="..\\icons\\icon.ico" />
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="LocalAppDataFolder">
@@ -35,8 +37,6 @@
       <!-- Stable GUID preserved (was previously used for per-user component). -->
       <Component Id="MainExecutableComponent" Guid="7E0DAB8B-2D40-4D2B-9B3D-2B2C3E5C902F">
         <File Id="MainExecutable" Source="$(var.SourceDir)" />
-        <!-- Icon reference for ARPPRODUCTICON (must be in Binary table) -->
-        <Icon Id="AppExeIcon" SourceFile="$(var.SourceDir)" />
         <!-- HKCU registry key as KeyPath satisfies ICE38 for per-user profile folder install -->
         <RegistryKey Root="HKCU" Key="Software\[Manufacturer]\[ProductName]">
           <RegistryValue Id="RegInstallDir" Name="InstallDir" Type="string" Value="[INSTALLFOLDER]" KeyPath="yes" />

--- a/src-tauri/wix/main.wxs
+++ b/src-tauri/wix/main.wxs
@@ -11,7 +11,10 @@
     <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" InstallPrivileges="limited" />
 
     <!-- Explicit per-user context (Windows Installer uses ALLUSERS=2 for pure per-user packages) -->
-    <Property Id="ALLUSERS" Value="2" />
+  <Property Id="ALLUSERS" Value="2" />
+  <!-- ARP metadata: icon & About URL (optional enhancement) -->
+  <Property Id="ARPPRODUCTICON" Value="AppExeIcon" />
+  <Property Id="ARPURLINFOABOUT" Value="https://github.com/Wootehfook/BoxdBuddies" />
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
     <MediaTemplate EmbedCab="yes" />
@@ -32,6 +35,8 @@
       <!-- Stable GUID preserved (was previously used for per-user component). -->
       <Component Id="MainExecutableComponent" Guid="7E0DAB8B-2D40-4D2B-9B3D-2B2C3E5C902F">
         <File Id="MainExecutable" Source="$(var.SourceDir)" />
+        <!-- Icon reference for ARPPRODUCTICON (must be in Binary table) -->
+        <Icon Id="AppExeIcon" SourceFile="$(var.SourceDir)" />
         <!-- HKCU registry key as KeyPath satisfies ICE38 for per-user profile folder install -->
         <RegistryKey Root="HKCU" Key="Software\[Manufacturer]\[ProductName]">
           <RegistryValue Id="RegInstallDir" Name="InstallDir" Type="string" Value="[INSTALLFOLDER]" KeyPath="yes" />


### PR DESCRIPTION
## Summary
Adds detailed per-user MSI documentation, introduces optional GPG signing for CHECKSUMS.txt, enhances release and test workflows with silent install/uninstall smoke tests, and adds ARP metadata (icon + URL) to the WiX installer.

## Changes
- README: Per-user MSI section, code signing guidance, GPG verification instructions
- WiX (main.wxs): ARPPRODUCTICON + ARPURLINFOABOUT, proper Icon placement
- windows-peruser-msi-test workflow: Silent install/uninstall smoke test
- release workflow: Silent install/uninstall test + conditional GPG signing step, signature upload
- Added issue #16 tracking future all-users MSI variant (separate artifact approach)

## Rationale
Improves security (integrity & authenticity), user clarity on installer scope, and automated assurance that the MSI installs and uninstalls cleanly in CI.

## Verification
- Lint & pre-commit passed locally (husky/lint-staged)
- Workflows syntactically valid (YAML structure unchanged except added steps)
- WiX file builds per prior baseline; Icon moved to Product scope (valid for ARPPRODUCTICON)

## Follow-Up
See issue #16 for optional per-machine installer variant.

---
AI Generated: GitHub Copilot - 2025-08-09
