### PR TITLE
🚀 Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-web-frontend.yml
+++ b/.github/workflows/deploy-web-frontend.yml
@@ -1,0 +1,59 @@
+name: Deploy Web Frontend to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'web/frontend/**' ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'web/frontend/package-lock.json'
+          
+      - name: Install dependencies
+        run: |
+          cd web/frontend
+          npm ci
+          
+      - name: Build frontend
+        run: |
+          cd web/frontend
+          npm run build
+          
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'web/frontend/dist'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
# 🚀 GitHub Pages Deployment Workflow

## What This Adds
- **Automated GitHub Pages deployment** for the web frontend
- **Triggers on changes** to `web/frontend/` directory  
- **Builds React app** and deploys to GitHub Pages automatically
- **Public URL** will be: `https://wootehfook.github.io/BoxdBuddies/`

## Why This Is Needed
The web migration is complete and ready for public testing. This workflow enables:
1. **Immediate deployment** when frontend changes are pushed
2. **Public testing URL** for iterative feedback 
3. **Automated CI/CD** for the web application

## Testing Process
Once merged:
1. GitHub Pages will automatically deploy the frontend
2. You'll get a public URL for testing
3. We can iterate quickly based on your feedback

Ready to enable public testing of the BoxdBuddies web application! 🎬