### PR TITLE
🔧 Fix Cloudflare Pages base path configuration

### DIFF
--- a/web/frontend/vite.config.ts
+++ b/web/frontend/vite.config.ts
@@ -5,8 +5,8 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
 
-  // Configuration for GitHub Pages deployment
-  base: "/BoxdBuddies/",
+  // Configuration for Cloudflare Pages deployment
+  base: "/",
 
   // Build configuration
   build: {


### PR DESCRIPTION
## 🔧 Fix: Cloudflare Pages Deployment Issue

**Problem**: Cloudflare Pages showing blank page despite successful builds

**Root Cause**: Vite configuration using GitHub Pages base path (`/BoxdBuddies/`) instead of Cloudflare Pages root path (`/`)

**Solution**: 
- ✅ Changed `vite.config.ts` base path from `/BoxdBuddies/` to `/`
- ✅ Updated comments to reflect Cloudflare Pages deployment
- ✅ Tested locally - build generates correct asset paths

**Impact**: Assets will load correctly from root domain, resolving the blank page issue

**Files Changed**: 
- `web/frontend/vite.config.ts` - Single line change for base path