### PR TITLE
ci(codeql): fix CodeQL jobs by building Rust in src-tauri and setting up Node for JS

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,14 +27,35 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node.js (for JavaScript/TypeScript analysis)
+        if: matrix.language == 'javascript'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install JS deps (no scripts)
+        if: matrix.language == 'javascript'
+        run: |
+          npm ci --ignore-scripts
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          build-mode: autobuild
+          build-mode: ${{ matrix.language == 'rust' && 'manual' || 'autobuild' }}
 
-      - name: Autobuild
+      - name: Autobuild (non-Rust)
+        if: matrix.language != 'rust'
         uses: github/codeql-action/autobuild@v3
+
+      - name: Build Rust workspace (src-tauri)
+        if: matrix.language == 'rust'
+        working-directory: src-tauri
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          cargo fetch
+          cargo build --locked --release
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Fix failing non-required checks.

- Rust: switch CodeQL to manual build and build src-tauri explicitly with stable toolchain
- JS: setup Node 20 and install deps (no scripts) so code scanning has a proper dependency graph
- Keep matrix for ['rust','javascript'] and fail-fast disabled

This should stabilize CodeQL jobs on PRs (including #43) without affecting app behavior.