### PR TITLE
chore(lint,docs): type dialog ref and document ESLint global

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,16 +47,17 @@ Letterboxd/TMDB integration
 Frontend touchpoints
 
 - API calls from `src/` services/components; strict TypeScript (no `any`); React Testing Library used under `src/__tests__/`
-- Attribution modal (frontend): implemented as a native `<dialog>` in `src/App.tsx` with a centered trigger button labeled `Data sources & attribution`.
+- Attribution modal (frontend): native `<dialog>` in `src/App.tsx` with a centered trigger button labeled `Data sources & attribution`.
   - Uses a backdrop button element (`.modal-backdrop-button`) for closing; dialog also has an internal Close button and `onClose` handler to sync React state.
   - Dialog has `aria-labelledby="attribution-title"` and `aria-modal="true"` for accessibility.
   - Focus is moved into the dialog on open; Escape and backdrop click close it.
+  - Types: dialog ref uses `useRef<HTMLDialogElement | null>` and `eslint.config.js` declares `HTMLDialogElement` as a global to satisfy ESLint.
 
 Testing patterns to mirror
 
 - Endpoint auth/validation/rate limit/CORS: `functions/__tests__/watchlist-count-updates.test.ts`
 - Cache integration: `functions/__tests__/friends-cache-integration.test.ts`
-- Modal testing in jsdom: `src/__tests__/attribution-modal.test.tsx` uses `userEvent.setup()`, disambiguates duplicate text (button vs heading) via `findAllByText` and tag checks, and closes via the backdrop button for determinism (jsdom may not expose `<dialog>` role reliably).
+- Modal testing in jsdom: `src/__tests__/attribution-modal.test.tsx` uses `userEvent.setup()`, disambiguates duplicate text (button vs heading) via `findAllByText` and tag checks, and closes via the backdrop button for determinism (jsdom’s `<dialog>` role support can vary).
 
 MCP servers (optional)
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,7 @@ export default [
         clearInterval: "readonly",
         MouseEvent: "readonly",
         HTMLElement: "readonly",
+        HTMLDialogElement: "readonly",
       },
     },
     plugins: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,17 +136,15 @@ function App() {
 
   // Local UI state for the attribution modal
   const [showAttribution, setShowAttribution] = useState(false);
-  // Use a neutral HTMLElement ref to avoid requiring lib.dom in TS config
-  const modalRef = useRef<HTMLElement | null>(null);
+  // Use a typed HTMLDialogElement ref for safe dialog method access
+  const modalRef = useRef<HTMLDialogElement | null>(null);
 
   // When modal opens, show the native dialog when available and move focus into it for accessibility
   useEffect(() => {
     const dialog = modalRef.current;
     if (showAttribution && dialog) {
       try {
-        // Cast to any because the DOM dialog methods aren't available in all TS configs
-        if (typeof (dialog as any).showModal === "function")
-          (dialog as any).showModal();
+        if (typeof dialog.showModal === "function") dialog.showModal();
       } catch {
         // ignore if not supported
       }
@@ -154,8 +152,7 @@ function App() {
       setTimeout(() => dialog?.focus(), 0);
     } else if (!showAttribution && dialog) {
       try {
-        if (typeof (dialog as any).close === "function")
-          (dialog as any).close();
+        if (typeof dialog.close === "function") dialog.close();
       } catch {
         // ignore
       }
@@ -545,7 +542,7 @@ function App() {
               aria-labelledby="attribution-title"
               aria-modal="true"
               ref={(el) => {
-                modalRef.current = el as HTMLElement | null;
+                modalRef.current = el;
               }}
               tabIndex={-1}
               onClose={() => setShowAttribution(false)}


### PR DESCRIPTION
This PR finishes the attribution modal typing cleanup and docs:

- Types the modal ref as HTMLDialogElement | null in src/App.tsx and removes ny casts.
- Adds HTMLDialogElement to ESLint globals in slint.config.js so lint no longer flags it as undefined.
- Updates .github/copilot-instructions.md to document the typed dialog ref and ESLint global, and clarifies jsdom dialog role note.

Quality gates:
- npm run type-check: PASS
- npm run lint: PASS (no warnings/errors)
- npm run build: PASS
- npm run test: PASS (all tests)

No runtime behavior changes; strictly typing + lint config + docs.