### PR TITLE
Potential fix for code scanning alert no. 48: Double escaping or unescaping

### DIFF
--- a/functions/letterboxd/[username].ts
+++ b/functions/letterboxd/[username].ts
@@ -153,9 +153,9 @@ async function scrapeUserWatchlist(
     for (const match of movieMatches) {
       const slug = match[1];
       const title = match[2]
-        .replace(/&amp;/g, "&")
         .replace(/&quot;/g, '"')
-        .replace(/&#x27;/g, "'");
+        .replace(/&#x27;/g, "'")
+        .replace(/&amp;/g, "&");
       const year = parseInt(match[3]);
 
       movies.push({


### PR DESCRIPTION
Potential fix for [https://github.com/Wootehfook/BoxdBuddies/security/code-scanning/48](https://github.com/Wootehfook/BoxdBuddies/security/code-scanning/48)

To fix this issue, we need to reorder the `.replace()` operations so that `&amp;` is replaced **last**. This prevents prematurely decoding ampersands that are part of other entities (like `&amp;quot;`). Specifically, in file `functions/letterboxd/[username].ts`, on the lines where the `title` is set, move `.replace(/&amp;/g, "&")` from first to last in the chain. No new imports or utility definitions needed; just a reordering of the three `.replace()` statements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
