### PR TITLE
fix: harden common helper typings for sonar

### DIFF
--- a/functions/_lib/common.d.ts
+++ b/functions/_lib/common.d.ts
@@ -6,33 +6,79 @@ export declare const corsHeaders: Record<string, string>;
 
 export declare function withCORS(response: Response): Response;
 
-export declare function jsonResponse(data: any, init?: any): Response;
+export declare function jsonResponse(
+  data: unknown,
+  init?: globalThis.ResponseInit
+): Response;
 
 // Use the global Cache type from DOM lib
 export declare function getCache(): globalThis.Cache | undefined | null;
 
-export declare function kvGetJson(kv: any, key: string): Promise<any | null>;
+export interface KvNamespaceLike {
+  get(key: string, options?: { type?: string }): Promise<unknown>;
+  put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number }
+  ): Promise<void>;
+}
+
+export declare function kvGetJson<T = unknown>(
+  kv: KvNamespaceLike | null | undefined,
+  key: string
+): Promise<T | null>;
 
 export declare function kvPutJson(
-  kv: any,
+  kv: KvNamespaceLike | null | undefined,
   key: string,
-  value: any,
+  value: unknown,
   ttl?: number
 ): Promise<void>;
 
+export interface TmdbEnvLike {
+  TMDB_API_KEY?: string;
+}
+
 export declare function tmdbFetch(
   path: string,
-  env: any,
-  init?: any
+  env: TmdbEnvLike,
+  init?: globalThis.RequestInit
 ): Promise<Response>;
 
-export declare function reduceMovie(m: any): any;
+export interface ReducedMovie {
+  id: unknown;
+  title: unknown;
+  year: number | null;
+  poster_path: string | null;
+  overview: unknown;
+  rating: unknown;
+  runtime: unknown;
+}
 
-export declare function toYear(d: any): number | null;
+export interface TmdbMovieInput {
+  id?: unknown;
+  title?: unknown;
+  release_date?: string | Date | null;
+  poster_path?: string | null;
+  overview?: unknown;
+  vote_average?: unknown;
+  runtime?: unknown;
+}
 
-export declare function isDebug(env?: any): boolean;
+export declare function reduceMovie(m: TmdbMovieInput): ReducedMovie;
 
-export declare function debugLog(env: any, ...args: any[]): void;
+export declare function toYear(
+  d: string | number | Date | null | undefined
+): number | null;
+
+export type DebugEnvLike = object;
+
+export declare function isDebug(env?: DebugEnvLike | null): boolean;
+
+export declare function debugLog(
+  env: DebugEnvLike | null | undefined,
+  ...args: unknown[]
+): void;
 
 // Canonical declarations live in functions/_types/*.d.ts — keep these lightweight
 


### PR DESCRIPTION
## Summary\n- replace explicit `any` types in `functions/_lib/common.d.ts` with safer, structured declarations\n- add focused helper interfaces for KV, TMDB env, and reduced movie shape\n- keep debug helper env typing broad enough to remain compatible with existing `Env` types\n\n## Why\nThis starts the Sonar issue remediation work with a category-scoped PR targeting type-safety hotspots in shared helper declarations.\n\n## Validation\n- npm run type-check\n- npm run build\n- npm test -- --run\n- npx eslint functions/_lib/common.d.ts\n