### PR TITLE
fix: reduce explicit any usage in backend endpoints

### DIFF
--- a/functions/api/watchlist-count-updates/index.ts
+++ b/functions/api/watchlist-count-updates/index.ts
@@ -99,7 +99,10 @@ function checkRateLimit(
 }
 
 // Validate payload structure and values
-function validatePayload(payload: any): { valid: boolean; errors: string[] } {
+function validatePayload(payload: unknown): {
+  valid: boolean;
+  errors: string[];
+} {
   const errors: string[] = [];
 
   if (typeof payload !== "object" || payload === null) {
@@ -107,46 +110,48 @@ function validatePayload(payload: any): { valid: boolean; errors: string[] } {
     return { valid: false, errors };
   }
 
+  const candidate = payload as Partial<UpdatePayload>;
+
   // Required fields
-  if (typeof payload.username !== "string" || !payload.username.trim()) {
+  if (typeof candidate.username !== "string" || !candidate.username.trim()) {
     errors.push("username is required and must be a non-empty string");
   }
 
-  if (typeof payload.count !== "number") {
+  if (typeof candidate.count !== "number") {
     errors.push("count is required and must be a number");
-  } else if (payload.count < 0) {
+  } else if (candidate.count < 0) {
     errors.push("count must be >= 0");
-  } else if (!Number.isInteger(payload.count)) {
+  } else if (!Number.isInteger(candidate.count)) {
     errors.push("count must be an integer");
   }
 
   // Optional fields validation
-  if (payload.etag !== undefined && typeof payload.etag !== "string") {
+  if (candidate.etag !== undefined && typeof candidate.etag !== "string") {
     errors.push("etag must be a string if provided");
   }
 
-  if (payload.lastFetchedAt !== undefined) {
-    if (typeof payload.lastFetchedAt !== "number") {
-      errors.push("lastFetchedAt must be a number if provided");
-    } else {
+  if (candidate.lastFetchedAt !== undefined) {
+    if (typeof candidate.lastFetchedAt === "number") {
       const now = Date.now();
       const maxAge = 7 * 24 * 60 * 60 * 1000; // 7 days
       if (
-        payload.lastFetchedAt > now + 60000 ||
-        payload.lastFetchedAt < now - maxAge
+        candidate.lastFetchedAt > now + 60000 ||
+        candidate.lastFetchedAt < now - maxAge
       ) {
         errors.push("lastFetchedAt timestamp is unreasonable");
       }
+    } else {
+      errors.push("lastFetchedAt must be a number if provided");
     }
   }
 
-  if (payload.source !== undefined && payload.source !== "client") {
+  if (candidate.source !== undefined && candidate.source !== "client") {
     errors.push('source must be "client" if provided');
   }
 
   // Username sanitization
-  if (typeof payload.username === "string") {
-    const username = payload.username.trim();
+  if (typeof candidate.username === "string") {
+    const username = candidate.username.trim();
     if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
       errors.push("username contains invalid characters");
     }

--- a/functions/compare/index.ts
+++ b/functions/compare/index.ts
@@ -85,10 +85,11 @@ async function scrapeLetterboxdWatchlist(
     return movies;
   } catch (error) {
     console.error(`Error scraping ${username}:`, error);
-    throw new Error(
-      `Failed to scrape watchlist for ${username}. Make sure the username exists and the watchlist is public.`,
-      { cause: error }
+    const err = new Error(
+      `Failed to scrape watchlist for ${username}. Make sure the username exists and the watchlist is public.`
     );
+    err.cause = error;
+    throw err;
   }
 }
 

--- a/functions/compare/index.ts
+++ b/functions/compare/index.ts
@@ -86,7 +86,8 @@ async function scrapeLetterboxdWatchlist(
   } catch (error) {
     console.error(`Error scraping ${username}:`, error);
     throw new Error(
-      `Failed to scrape watchlist for ${username}. Make sure the username exists and the watchlist is public.`
+      `Failed to scrape watchlist for ${username}. Make sure the username exists and the watchlist is public.`,
+      { cause: error }
     );
   }
 }
@@ -98,6 +99,18 @@ async function scrapeLetterboxdWatchlist(
 interface CommonMovie extends LetterboxdMovie {
   friendCount: number;
   friendList: string[];
+}
+
+interface TmdbMovieRow {
+  id: number;
+  title: string;
+  year?: number;
+  poster_path?: string;
+  overview?: string;
+  vote_average?: number;
+  director?: string;
+  runtime?: number;
+  genres?: unknown;
 }
 
 // Find movies that appear in multiple watchlists using efficient set operations
@@ -227,7 +240,7 @@ async function enhanceWithTMDBData(
         const result = await stmt.all();
 
         if (result.results && result.results.length > 0) {
-          const tmdbMovie: any = result.results[0];
+          const tmdbMovie = result.results[0] as TmdbMovieRow;
 
           // Parse genres from D1 row (stored as JSON text or array)
           let genres: string[] | undefined;

--- a/functions/search/index.ts
+++ b/functions/search/index.ts
@@ -16,6 +16,36 @@ interface KVNamespace {
 // Extend the canonical CacheEnv with the KV namespace used by this function
 type Env = CacheEnv & { MOVIES_KV: KVNamespace };
 
+interface SearchRow {
+  id: number;
+  title: string;
+  year?: number | null;
+  poster_path?: string | null;
+  overview?: string | null;
+  vote_average?: number | null;
+  director?: string | null;
+  runtime?: number | null;
+}
+
+interface SearchCountRow {
+  total?: number;
+}
+
+interface TmdbSearchMovie {
+  id: number;
+  title: string;
+  release_date?: string;
+  poster_path?: string | null;
+  overview?: string;
+  vote_average?: number;
+  runtime?: number;
+}
+
+interface TmdbSearchResponse {
+  results?: TmdbSearchMovie[];
+  total_pages?: number;
+}
+
 // Temporarily unused interface - commenting out to fix lint warnings
 // interface MovieSearchResult { ... }
 
@@ -35,7 +65,8 @@ export async function onRequestGet(context: { request: Request; env: Env }) {
       .bind(`%${q}%`, `%${q}%`)
       .all();
 
-    const totalRecords = (countResult.results?.[0] as any)?.total || 0;
+    const totalRecords =
+      (countResult.results?.[0] as SearchCountRow)?.total || 0;
 
     const localResults = await env.MOVIES_DB.prepare(
       `SELECT * FROM tmdb_movies WHERE title LIKE ? OR original_title LIKE ? ORDER BY popularity DESC LIMIT ? OFFSET ?`
@@ -44,7 +75,7 @@ export async function onRequestGet(context: { request: Request; env: Env }) {
       .all();
 
     if (localResults.results && localResults.results.length > 0) {
-      const movies = (localResults.results as any[]).map((movie) => ({
+      const movies = (localResults.results as SearchRow[]).map((movie) => ({
         id: movie.id,
         title: movie.title,
         year: movie.year,
@@ -74,8 +105,8 @@ export async function onRequestGet(context: { request: Request; env: Env }) {
   if (!response.ok)
     return Response.json({ error: "tmdb_error" }, { status: 502 });
 
-  const data = await response.json();
-  const movies = (data.results || []).map((movie: any) => ({
+  const data = (await response.json()) as TmdbSearchResponse;
+  const movies = (data.results || []).map((movie) => ({
     id: movie.id,
     title: movie.title,
     year: movie.release_date

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## Summary\n- replace explicit `any` use in `functions/search/index.ts` with typed TMDB/D1 result interfaces\n- make watchlist update payload validation accept `unknown` and narrow safely in `functions/api/watchlist-count-updates/index.ts`\n- tighten TMDB row typing in `functions/compare/index.ts` and preserve caught error cause\n\n## Why\nContinues Sonar remediation by addressing explicit-any/type-safety findings in low-risk backend endpoint code paths.\n\n## Validation\n- npm run type-check\n- npx eslint functions/search/index.ts functions/api/watchlist-count-updates/index.ts functions/compare/index.ts\n- npm test -- --run functions/__tests__/watchlist-count-updates.test.ts functions/__tests__/watchlist-comparison.integration.test.ts\n