### PR TITLE
fix: tighten ambient common module declarations

### DIFF
--- a/functions/_types/ambient-common.d.ts
+++ b/functions/_types/ambient-common.d.ts
@@ -1,49 +1,141 @@
 // AI Generated: GitHub Copilot - 2025-09-06
 // Explicit ambient declarations for runtime helper import variants
 declare module "../../_lib/common" {
+  export interface KvNamespaceLike {
+    get(key: string, options?: { type?: string }): Promise<unknown>;
+    put(
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number }
+    ): Promise<void>;
+  }
+
+  export interface TmdbEnvLike {
+    TMDB_API_KEY?: string;
+  }
+
+  export interface TmdbMovieInput {
+    id?: unknown;
+    title?: unknown;
+    release_date?: string | Date | null;
+    poster_path?: string | null;
+    overview?: unknown;
+    vote_average?: unknown;
+    runtime?: unknown;
+  }
+
+  export interface ReducedMovie {
+    id: unknown;
+    title: unknown;
+    year: number | null;
+    poster_path: string | null;
+    overview: unknown;
+    rating: unknown;
+    runtime: unknown;
+  }
+
+  export type DebugEnvLike = object;
+
   export const corsHeaders: Record<string, string>;
   export function withCORS(response: Response): Response;
-  export function jsonResponse(data: any, init?: any): Response;
+  export function jsonResponse(
+    data: unknown,
+    init?: globalThis.ResponseInit
+  ): Response;
   export function getCache(): globalThis.Cache | undefined | null;
-  export function kvGetJson(kv: any, key: string): Promise<any | null>;
+  export function kvGetJson<T = unknown>(
+    kv: KvNamespaceLike | null | undefined,
+    key: string
+  ): Promise<T | null>;
   export function kvPutJson(
-    kv: any,
+    kv: KvNamespaceLike | null | undefined,
     key: string,
-    value: any,
+    value: unknown,
     ttl?: number
   ): Promise<void>;
   export function tmdbFetch(
     path: string,
-    env: any,
-    init?: any
+    env: TmdbEnvLike,
+    init?: globalThis.RequestInit
   ): Promise<Response>;
-  export function reduceMovie(m: any): any;
+  export function reduceMovie(m: TmdbMovieInput): ReducedMovie;
   export function parseGenresToNames(genres: unknown): string[] | undefined;
-  export function toYear(d: any): number | null;
-  export function isDebug(env?: any): boolean;
-  export function debugLog(env: any, ...args: any[]): void;
+  export function toYear(
+    d: string | number | Date | null | undefined
+  ): number | null;
+  export function isDebug(env?: DebugEnvLike | null): boolean;
+  export function debugLog(
+    env: DebugEnvLike | null | undefined,
+    ...args: unknown[]
+  ): void;
 }
 
 declare module "../../_lib/common.js" {
+  export interface KvNamespaceLike {
+    get(key: string, options?: { type?: string }): Promise<unknown>;
+    put(
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number }
+    ): Promise<void>;
+  }
+
+  export interface TmdbEnvLike {
+    TMDB_API_KEY?: string;
+  }
+
+  export interface TmdbMovieInput {
+    id?: unknown;
+    title?: unknown;
+    release_date?: string | Date | null;
+    poster_path?: string | null;
+    overview?: unknown;
+    vote_average?: unknown;
+    runtime?: unknown;
+  }
+
+  export interface ReducedMovie {
+    id: unknown;
+    title: unknown;
+    year: number | null;
+    poster_path: string | null;
+    overview: unknown;
+    rating: unknown;
+    runtime: unknown;
+  }
+
+  export type DebugEnvLike = object;
+
   export const corsHeaders: Record<string, string>;
   export function withCORS(response: Response): Response;
-  export function jsonResponse(data: any, init?: any): Response;
+  export function jsonResponse(
+    data: unknown,
+    init?: globalThis.ResponseInit
+  ): Response;
   export function getCache(): globalThis.Cache | undefined | null;
-  export function kvGetJson(kv: any, key: string): Promise<any | null>;
+  export function kvGetJson<T = unknown>(
+    kv: KvNamespaceLike | null | undefined,
+    key: string
+  ): Promise<T | null>;
   export function kvPutJson(
-    kv: any,
+    kv: KvNamespaceLike | null | undefined,
     key: string,
-    value: any,
+    value: unknown,
     ttl?: number
   ): Promise<void>;
   export function tmdbFetch(
     path: string,
-    env: any,
-    init?: any
+    env: TmdbEnvLike,
+    init?: globalThis.RequestInit
   ): Promise<Response>;
-  export function reduceMovie(m: any): any;
+  export function reduceMovie(m: TmdbMovieInput): ReducedMovie;
   export function parseGenresToNames(genres: unknown): string[] | undefined;
-  export function toYear(d: any): number | null;
-  export function isDebug(env?: any): boolean;
-  export function debugLog(env: any, ...args: any[]): void;
+  export function toYear(
+    d: string | number | Date | null | undefined
+  ): number | null;
+  export function isDebug(env?: DebugEnvLike | null): boolean;
+  export function debugLog(
+    env: DebugEnvLike | null | undefined,
+    ...args: unknown[]
+  ): void;
 }

--- a/functions/_types/common-modules.d.ts
+++ b/functions/_types/common-modules.d.ts
@@ -3,29 +3,111 @@
 // so TypeScript recognizes imports like '../../_lib/common' and '../../_lib/common.js'
 
 declare module "*_lib/common" {
-  export function debugLog(env: any, ...args: any[]): void;
-  export function isDebug(env?: any): boolean;
+  export interface KvNamespaceLike {
+    get(key: string, options?: { type?: string }): Promise<unknown>;
+    put(
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number }
+    ): Promise<void>;
+  }
+
+  export interface TmdbEnvLike {
+    TMDB_API_KEY?: string;
+  }
+
+  export interface TmdbMovieInput {
+    id?: unknown;
+    title?: unknown;
+    release_date?: string | Date | null;
+    poster_path?: string | null;
+    overview?: unknown;
+    vote_average?: unknown;
+    runtime?: unknown;
+  }
+
+  export interface ReducedMovie {
+    id: unknown;
+    title: unknown;
+    year: number | null;
+    poster_path: string | null;
+    overview: unknown;
+    rating: unknown;
+    runtime: unknown;
+  }
+
+  export type DebugEnvLike = object;
+
+  export function debugLog(
+    env: DebugEnvLike | null | undefined,
+    ...args: unknown[]
+  ): void;
+  export function isDebug(env?: DebugEnvLike | null): boolean;
   export const corsHeaders: Record<string, string>;
-  export function jsonResponse(data: any, init?: any): Response;
+  export function jsonResponse(
+    data: unknown,
+    init?: globalThis.ResponseInit
+  ): Response;
   export function tmdbFetch(
     path: string,
-    env: any,
-    init?: any
+    env: TmdbEnvLike,
+    init?: globalThis.RequestInit
   ): Promise<Response>;
-  export function reduceMovie(m: any): any;
+  export function reduceMovie(m: TmdbMovieInput): ReducedMovie;
   export function parseGenresToNames(genres: unknown): string[] | undefined;
 }
 
 declare module "*_lib/common.js" {
-  export function debugLog(env: any, ...args: any[]): void;
-  export function isDebug(env?: any): boolean;
+  export interface KvNamespaceLike {
+    get(key: string, options?: { type?: string }): Promise<unknown>;
+    put(
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number }
+    ): Promise<void>;
+  }
+
+  export interface TmdbEnvLike {
+    TMDB_API_KEY?: string;
+  }
+
+  export interface TmdbMovieInput {
+    id?: unknown;
+    title?: unknown;
+    release_date?: string | Date | null;
+    poster_path?: string | null;
+    overview?: unknown;
+    vote_average?: unknown;
+    runtime?: unknown;
+  }
+
+  export interface ReducedMovie {
+    id: unknown;
+    title: unknown;
+    year: number | null;
+    poster_path: string | null;
+    overview: unknown;
+    rating: unknown;
+    runtime: unknown;
+  }
+
+  export type DebugEnvLike = object;
+
+  export function debugLog(
+    env: DebugEnvLike | null | undefined,
+    ...args: unknown[]
+  ): void;
+  export function isDebug(env?: DebugEnvLike | null): boolean;
   export const corsHeaders: Record<string, string>;
-  export function jsonResponse(data: any, init?: any): Response;
+  export function jsonResponse(
+    data: unknown,
+    init?: globalThis.ResponseInit
+  ): Response;
   export function tmdbFetch(
     path: string,
-    env: any,
-    init?: any
+    env: TmdbEnvLike,
+    init?: globalThis.RequestInit
   ): Promise<Response>;
-  export function reduceMovie(m: any): any;
+  export function reduceMovie(m: TmdbMovieInput): ReducedMovie;
   export function parseGenresToNames(genres: unknown): string[] | undefined;
 }


### PR DESCRIPTION
## Summary\n- replace explicit `any` in ambient common module declaration files with structured helper interfaces and `unknown`\n- align ambient signatures with the canonical common helper declarations\n- keep runtime behavior unchanged (type-only declarations)\n\n## Why\nAddresses Sonar type-safety findings in declaration layers used by Cloudflare Functions imports.\n\n## Validation\n- npm run type-check\n- npx eslint functions/_types/common-modules.d.ts functions/_types/ambient-common.d.ts\n