### PR TITLE
fix: tighten cache and friends runtime typings

### DIFF
--- a/functions/api/watchlist-comparison/index.ts
+++ b/functions/api/watchlist-comparison/index.ts
@@ -591,9 +591,8 @@ const reportTmdbCatalogCount = async (env: Env, debugInfo: DebugInfo) => {
   try {
     const countRes = await env.MOVIES_DB.prepare(
       `SELECT COUNT(*) as c FROM tmdb_movies`
-    ).first();
-    debugInfo.db.tmdb_catalog_count =
-      (countRes && (countRes.c || countRes["c"])) || 0;
+    ).first<{ c?: number }>();
+    debugInfo.db.tmdb_catalog_count = Number(countRes?.c ?? 0);
   } catch (err) {
     debugInfo.db.tmdb_catalog_count = null;
     debugLog(

--- a/functions/compare/index.ts
+++ b/functions/compare/index.ts
@@ -241,7 +241,7 @@ async function enhanceWithTMDBData(
         const result = await stmt.all();
 
         if (result.results && result.results.length > 0) {
-          const tmdbMovie = result.results[0] as TmdbMovieRow;
+          const tmdbMovie = result.results[0] as unknown as TmdbMovieRow;
 
           // Parse genres from D1 row (stored as JSON text or array)
           let genres: string[] | undefined;

--- a/functions/letterboxd/avatar-proxy/index.ts
+++ b/functions/letterboxd/avatar-proxy/index.ts
@@ -37,7 +37,7 @@ function isValidLetterboxdUrl(url: string): boolean {
 export async function onRequest(context: {
   request: Request;
   env: {
-    MOVIES_DB: any; // D1Database type
+    MOVIES_DB: unknown;
   };
 }) {
   // Set CORS headers

--- a/functions/letterboxd/cache/index.ts
+++ b/functions/letterboxd/cache/index.ts
@@ -6,8 +6,19 @@
 
 import { debugLog } from "../../_lib/common";
 
+interface D1PreparedStatementLike {
+  bind(...values: unknown[]): D1PreparedStatementLike;
+  first<T = Record<string, unknown>>(): Promise<T | null>;
+  all<T = Record<string, unknown>>(): Promise<{ results: T[] }>;
+  run(): Promise<{ meta: { changes: number } }>;
+}
+
+interface D1DatabaseLike {
+  prepare(query: string): D1PreparedStatementLike;
+}
+
 export interface Env {
-  MOVIES_DB: any; // D1Database type
+  MOVIES_DB: D1DatabaseLike;
   TMDB_API_KEY: string;
   UPSTASH_REDIS_REST_URL?: string;
   UPSTASH_REDIS_REST_TOKEN?: string;
@@ -216,7 +227,7 @@ export async function onRequestPost(context: { request: Request; env: Env }) {
 }
 
 async function getCachedFriends(
-  database: any,
+  database: D1DatabaseLike,
   username: string
 ): Promise<FriendsCache | null> {
   try {
@@ -229,7 +240,11 @@ async function getCachedFriends(
     `
       )
       .bind(username)
-      .first();
+      .first<{
+        friends_data: string;
+        last_updated: number;
+        expires_at: number;
+      }>();
 
     if (!result) {
       return null;
@@ -242,16 +257,13 @@ async function getCachedFriends(
       expiresAt: result.expires_at,
     };
   } catch (error) {
-    debugLog(
-      undefined as any,
-      `Error getting cached friends: ${String(error)}`
-    );
+    debugLog(undefined, `Error getting cached friends: ${String(error)}`);
     return null;
   }
 }
 
 async function setCachedFriends(
-  database: any,
+  database: D1DatabaseLike,
   username: string,
   friends: FriendLike[] | CachedFriend[],
   env?: Env
@@ -263,14 +275,15 @@ async function setCachedFriends(
     // Normalize to CachedFriend[] by ensuring lastUpdated is present. This
     // allows callers to pass either the raw scraped friend objects or already
     // annotated CachedFriend objects.
+    type FriendCacheInput = FriendLike & { lastUpdated?: number };
     const normalizedFriends: CachedFriend[] = (
-      friends as (FriendLike | CachedFriend)[]
+      friends as FriendCacheInput[]
     ).map((f) => ({
       username: f.username,
-      displayName: (f as any).displayName,
-      watchlistCount: (f as any).watchlistCount,
-      profileImageUrl: (f as any).profileImageUrl,
-      lastUpdated: (f as any).lastUpdated ?? now,
+      displayName: f.displayName,
+      watchlistCount: f.watchlistCount,
+      profileImageUrl: f.profileImageUrl,
+      lastUpdated: f.lastUpdated ?? now,
     }));
 
     await database
@@ -286,7 +299,7 @@ async function setCachedFriends(
 
     debugLog(env, `Cached ${normalizedFriends.length} friends for ${username}`);
   } catch (error) {
-    debugLog(env as any, `Error caching friends: ${String(error)}`);
+    debugLog(env, `Error caching friends: ${String(error)}`);
     // Don't throw - caching is not critical
   }
 }
@@ -337,7 +350,7 @@ export async function getCount(
     // Fallback to D1
     return await getCountFromD1(username, env);
   } catch (error) {
-    debugLog(env as any, `Error getting cached count: ${String(error)}`);
+    debugLog(env, `Error getting cached count: ${String(error)}`);
     return null;
   }
 }
@@ -369,7 +382,7 @@ export async function setCount(
     // Also store in D1 as backup
     await setCountInD1(username, payload, env);
   } catch (error) {
-    debugLog(env as any, `Error setting cached count: ${String(error)}`);
+    debugLog(env, `Error setting cached count: ${String(error)}`);
     throw error;
   }
 }
@@ -416,7 +429,7 @@ export async function acquireLock(
     // Handle both "OK" response and numeric response (1 for success, 0 for failure)
     return result.result === "OK" || result.result === 1;
   } catch (error) {
-    debugLog(env as any, `Error acquiring Redis lock: ${String(error)}`);
+    debugLog(env, `Error acquiring Redis lock: ${String(error)}`);
     // Fallback to D1
     return await acquireLockD1(username, timeoutMs, env);
   }
@@ -449,7 +462,7 @@ export async function releaseLock(username: string, env: Env): Promise<void> {
       throw new Error(`Redis request failed: ${response.status}`);
     }
   } catch (error) {
-    debugLog(env as any, `Error releasing Redis lock: ${String(error)}`);
+    debugLog(env, `Error releasing Redis lock: ${String(error)}`);
     // Fallback to D1
     await releaseLockD1(username, env);
   }
@@ -498,7 +511,7 @@ async function getCountFromRedis(
 
     return data;
   } catch (error) {
-    debugLog(env as any, `Error getting count from Redis: ${String(error)}`);
+    debugLog(env, `Error getting count from Redis: ${String(error)}`);
     return null;
   }
 }
@@ -527,7 +540,7 @@ async function setCountInRedis(
       throw new Error(`Redis set failed: ${response.status}`);
     }
   } catch (error) {
-    debugLog(env as any, `Error setting count in Redis: ${String(error)}`);
+    debugLog(env, `Error setting count in Redis: ${String(error)}`);
     throw error;
   }
 }
@@ -542,7 +555,7 @@ async function getCountFromD1(
       "SELECT value, expires_at FROM watchlist_counts_cache WHERE username = ?"
     )
       .bind(username)
-      .first();
+      .first<{ value: string; expires_at: number }>();
 
     if (!result) {
       return null;
@@ -555,7 +568,7 @@ async function getCountFromD1(
 
     return JSON.parse(result.value);
   } catch (error) {
-    debugLog(env as any, `Error getting count from D1: ${String(error)}`);
+    debugLog(env, `Error getting count from D1: ${String(error)}`);
     return null;
   }
 }
@@ -577,7 +590,7 @@ async function setCountInD1(
       .bind(username, JSON.stringify(payload), expiresAt)
       .run();
   } catch (error) {
-    debugLog(env as any, `Error setting count in D1: ${String(error)}`);
+    debugLog(env, `Error setting count in D1: ${String(error)}`);
     throw error;
   }
 }
@@ -599,7 +612,7 @@ async function acquireLockD1(
 
     return result.meta.changes > 0; // True if inserted (lock acquired)
   } catch (error) {
-    debugLog(env as any, `Error acquiring D1 lock: ${String(error)}`);
+    debugLog(env, `Error acquiring D1 lock: ${String(error)}`);
     return false;
   }
 }
@@ -612,6 +625,6 @@ async function releaseLockD1(username: string, env: Env): Promise<void> {
       .bind(lockKey)
       .run();
   } catch (error) {
-    debugLog(env as any, `Error releasing D1 lock: ${String(error)}`);
+    debugLog(env, `Error releasing D1 lock: ${String(error)}`);
   }
 }

--- a/functions/letterboxd/cache/index.ts
+++ b/functions/letterboxd/cache/index.ts
@@ -6,14 +6,14 @@
 
 import { debugLog } from "../../_lib/common";
 
-interface D1PreparedStatementLike {
+export interface D1PreparedStatementLike {
   bind(...values: unknown[]): D1PreparedStatementLike;
   first<T = Record<string, unknown>>(): Promise<T | null>;
   all<T = Record<string, unknown>>(): Promise<{ results: T[] }>;
   run(): Promise<{ meta: { changes: number } }>;
 }
 
-interface D1DatabaseLike {
+export interface D1DatabaseLike {
   prepare(query: string): D1PreparedStatementLike;
 }
 

--- a/functions/letterboxd/friends/index.ts
+++ b/functions/letterboxd/friends/index.ts
@@ -16,6 +16,20 @@ interface Friend {
   profileImageUrl?: string;
 }
 
+interface D1PreparedStatementLike {
+  bind(...values: unknown[]): D1PreparedStatementLike;
+  first<T = Record<string, unknown>>(): Promise<T | null>;
+  run(): Promise<{ meta: { changes: number } }>;
+}
+
+interface D1DatabaseLike {
+  prepare(query: string): D1PreparedStatementLike;
+}
+
+interface ClientWatchlistEntry {
+  count?: number;
+}
+
 // Rate limiting - 1 second between requests
 // Internal helper: ensures we don't flood Letterboxd with requests when
 // scraping multiple users in quick succession. This function is intentionally
@@ -190,7 +204,7 @@ export async function scrapeLetterboxdFriends(
     debugLog(env, `Found ${friends.length} friends for ${username}`);
     return friends;
   } catch (error) {
-    debugLog(env as any, `Error scraping Letterboxd friends: ${String(error)}`);
+    debugLog(env, `Error scraping Letterboxd friends: ${String(error)}`);
     throw error;
   }
 }
@@ -367,7 +381,7 @@ export async function onRequestPost(context: {
 // Watchlist count attachment logic
 async function attachWatchlistCounts(
   friends: Friend[],
-  clientWatchlistCache: any,
+  clientWatchlistCache: Record<string, ClientWatchlistEntry> | undefined,
   env: CacheEnv
 ): Promise<Friend[]> {
   const friendsWithCounts = [];
@@ -409,7 +423,7 @@ async function attachWatchlistCounts(
 const CACHE_DURATION_MS = 6 * 60 * 60 * 1000; // 6 hours
 
 async function getCachedFriends(
-  database: any,
+  database: D1DatabaseLike,
   username: string
 ): Promise<{
   friends: Friend[];
@@ -426,7 +440,11 @@ async function getCachedFriends(
     `
       )
       .bind(username)
-      .first();
+      .first<{
+        friends_data: string;
+        last_updated: number;
+        expires_at: number;
+      }>();
 
     if (!result) {
       return null;
@@ -444,7 +462,7 @@ async function getCachedFriends(
 }
 
 async function setCachedFriends(
-  database: any,
+  database: D1DatabaseLike,
   username: string,
   friends: Friend[],
   env?: CacheEnv

--- a/functions/letterboxd/friends/index.ts
+++ b/functions/letterboxd/friends/index.ts
@@ -7,23 +7,13 @@
 // Import cache functions and shared Env type to keep types consistent
 import { getCount } from "../cache/index.js";
 import { debugLog } from "../../_lib/common";
-import type { Env as CacheEnv } from "../cache/index.js";
+import type { Env as CacheEnv, D1DatabaseLike } from "../cache/index.js";
 
 interface Friend {
   username: string;
   displayName?: string;
   watchlistCount?: number;
   profileImageUrl?: string;
-}
-
-interface D1PreparedStatementLike {
-  bind(...values: unknown[]): D1PreparedStatementLike;
-  first<T = Record<string, unknown>>(): Promise<T | null>;
-  run(): Promise<{ meta: { changes: number } }>;
-}
-
-interface D1DatabaseLike {
-  prepare(query: string): D1PreparedStatementLike;
 }
 
 interface ClientWatchlistEntry {

--- a/functions/search/index.ts
+++ b/functions/search/index.ts
@@ -75,7 +75,7 @@ export async function onRequestGet(context: { request: Request; env: Env }) {
       .all();
 
     if (localResults.results && localResults.results.length > 0) {
-      const movies = (localResults.results as SearchRow[]).map((movie) => ({
+      const movies = (localResults.results as unknown as SearchRow[]).map((movie) => ({
         id: movie.id,
         title: movie.title,
         year: movie.year,


### PR DESCRIPTION
## Summary\n- replace explicit `any` usage in letterboxd cache/friends/avatar modules with minimal D1 and payload interfaces\n- remove unnecessary `env as any` casts in cache logging paths\n- add shared D1 statement `all()` typing compatibility and typed TMDB catalog count query in watchlist comparison\n\n## Why\nContinues Sonar type-safety remediation for backend cache/friends paths with behavior-preserving typing updates.\n\n## Validation\n- npm run type-check\n- npx eslint functions/letterboxd/cache/index.ts functions/letterboxd/friends/index.ts functions/letterboxd/avatar-proxy/index.ts functions/api/watchlist-comparison/index.ts\n- npm test -- --run functions/__tests__/friends-cache-integration.test.ts functions/__tests__/watchlist-comparison.integration.test.ts\n