### PR TITLE
fix: reduce any usage in letterboxd compare and test endpoints

### DIFF
--- a/functions/letterboxd/compare/index.ts
+++ b/functions/letterboxd/compare/index.ts
@@ -412,7 +412,7 @@ async function enhanceWithTMDBData(
       if (stripped) {
         const strippedResult = await dbFindStripped(stripped, movie.year);
         if (strippedResult?.results?.length)
-          return buildMovieFromRow(strippedResult.results[0], movie);
+          return buildMovieFromRow(strippedResult.results[0] as unknown as TmdbRow, movie);
       }
 
       let searchTitle = normalized;
@@ -449,7 +449,7 @@ async function enhanceWithTMDBData(
       }
 
       if (result?.results?.length)
-        return buildMovieFromRow(result.results[0], movie);
+        return buildMovieFromRow(result.results[0] as unknown as TmdbRow, movie);
 
       return {
         id: generateFallbackId(normalized, movie.year),

--- a/functions/letterboxd/compare/index.ts
+++ b/functions/letterboxd/compare/index.ts
@@ -6,7 +6,7 @@ import type { Env as CacheEnv } from "../cache/index.js";
 
 // Structured logging utility for production
 const logger = {
-  info: (message: string, meta?: any) => {
+  info: (message: string, meta?: unknown) => {
     debugLog(
       undefined,
       JSON.stringify({
@@ -17,17 +17,17 @@ const logger = {
       })
     );
   },
-  error: (message: string, error?: any) => {
+  error: (message: string, error?: unknown) => {
     console.error(
       JSON.stringify({
         level: "error",
         message,
-        error: error?.message || error,
+        error: error instanceof Error ? error.message : String(error ?? ""),
         timestamp: new Date().toISOString(),
       })
     );
   },
-  warn: (message: string, meta?: any) => {
+  warn: (message: string, meta?: unknown) => {
     debugLog(
       undefined,
       JSON.stringify({
@@ -61,6 +61,18 @@ interface Movie {
   letterboxdSlug?: string | null;
   friendCount: number;
   friendList: string[];
+}
+
+interface TmdbRow {
+  id: number;
+  title: string;
+  year?: number;
+  poster_path?: string | null;
+  overview?: string | null;
+  vote_average?: number | null;
+  director?: string | null;
+  runtime?: number | null;
+  genres?: unknown;
 }
 
 function decodeHTMLEntities(text: string): string {
@@ -280,10 +292,10 @@ async function enhanceWithTMDBData(
            ORDER BY popularity DESC
            LIMIT 1`;
       const stmt = env.MOVIES_DB.prepare(sql);
-      const binds = anyYear
+      const binds: unknown[] = anyYear
         ? ["'", titleStripped, "'", titleStripped]
         : ["'", titleStripped, "'", titleStripped, year, year - 1, year + 1];
-      return await stmt.bind(...(binds as any)).all();
+      return await stmt.bind(...binds).all();
     } catch (e) {
       debugLog(env, `Stripped REPLACE lookup failed: ${String(e)}`);
       return null;
@@ -310,10 +322,10 @@ async function enhanceWithTMDBData(
            ORDER BY popularity DESC
            LIMIT 1`;
       const stmt = env.MOVIES_DB.prepare(sql);
-      const binds = anyYear
+      const binds: unknown[] = anyYear
         ? [title, title]
         : [title, title, year, year - 1, year + 1];
-      return await stmt.bind(...(binds as any)).all();
+      return await stmt.bind(...binds).all();
     } catch (e) {
       debugLog(env, `Exact lookup failed: ${String(e)}`);
       return null;
@@ -369,11 +381,11 @@ async function enhanceWithTMDBData(
   }
 
   function buildMovieFromRow(
-    r: any,
+    r: TmdbRow,
     movie: LetterboxdMovie & { friendCount: number; friendList: string[] }
   ): Movie {
     // Parse genres via shared helper
-    const gnames = parseGenresToNames((r as any).genres);
+    const gnames = parseGenresToNames(r.genres);
     const genres: string[] | null = gnames ? [...gnames] : null;
     return {
       id: r.id,

--- a/functions/letterboxd/watchlist-count/index.ts
+++ b/functions/letterboxd/watchlist-count/index.ts
@@ -13,6 +13,16 @@ interface WatchlistCount {
   lastUpdated: number;
 }
 
+interface D1PreparedStatementLike {
+  bind(...values: unknown[]): D1PreparedStatementLike;
+  first<T = Record<string, unknown>>(): Promise<T | null>;
+  run(): Promise<{ meta: { changes: number } }>;
+}
+
+interface D1DatabaseLike {
+  prepare(query: string): D1PreparedStatementLike;
+}
+
 // Rate limiting - 1 second between requests to be respectful to Letterboxd
 let lastRequestTime = 0;
 const RATE_LIMIT_MS = 1000;
@@ -367,7 +377,7 @@ export async function onRequestPost(context: {
 
 // Cache management functions
 async function getCachedWatchlistCount(
-  database: any,
+  database: D1DatabaseLike,
   username: string
 ): Promise<WatchlistCount | null> {
   try {
@@ -380,7 +390,11 @@ async function getCachedWatchlistCount(
     `
       )
       .bind(username)
-      .first();
+      .first<{
+        username: string;
+        watchlist_count: number;
+        last_updated: number;
+      }>();
 
     if (!result) {
       return null;
@@ -398,7 +412,7 @@ async function getCachedWatchlistCount(
 }
 
 async function setCachedWatchlistCount(
-  database: any,
+  database: D1DatabaseLike,
   username: string,
   count: number,
   env?: CacheEnv

--- a/functions/test/movie-lookup.ts
+++ b/functions/test/movie-lookup.ts
@@ -5,6 +5,14 @@ import type { Env as CacheEnv } from "../letterboxd/cache/index.js";
 import { debugLog } from "../_lib/common";
 type Env = CacheEnv;
 
+interface TmdbLookupRow {
+  title?: string;
+  original_title?: string;
+  year?: number;
+  release_date?: string | null;
+  popularity?: number;
+}
+
 function normalizeTitle(t: string) {
   return t
     .toLowerCase()
@@ -68,11 +76,11 @@ async function findTmdbRowForMovie(title: string, year: number, env: Env) {
   )
     .bind(`%${t}%`, `%${t}%`)
     .all();
-  const candidates = (res.results || []) as any[];
+  const candidates = (res.results || []) as TmdbLookupRow[];
   if (candidates.length > 0) {
     const want = normalizeTitle(t);
     const wantYear = y || 0;
-    let best: any = null;
+    let best: TmdbLookupRow | null = null;
     let bestScore = -Infinity;
     for (const c of candidates) {
       const ct = normalizeTitle(String(c.title || c.original_title || ""));
@@ -125,7 +133,7 @@ export async function onRequestGet(context: { request: Request; env: Env }) {
     });
   } catch (err) {
     // Avoid exposing stack traces; log internally when debug is enabled
-    debugLog(context.env as any, "movie-lookup error", err);
+    debugLog(context.env, "movie-lookup error", err);
     return new Response(JSON.stringify({ error: "Internal server error" }), {
       status: 500,
       headers: { "Content-Type": "application/json", ...cors },

--- a/functions/test/movie-search.ts
+++ b/functions/test/movie-search.ts
@@ -1,5 +1,7 @@
 // AI Generated: GitHub Copilot - 2025-08-16
-export async function onRequest(context: any) {
+import type { Env as CacheEnv } from "../letterboxd/cache/index.js";
+
+export async function onRequest(context: { request: Request; env: CacheEnv }) {
   const { env } = context;
 
   try {

--- a/functions/test/tmdb-check.ts
+++ b/functions/test/tmdb-check.ts
@@ -1,5 +1,7 @@
 // AI Generated: GitHub Copilot - 2025-08-16
-export async function onRequest(context: any) {
+import type { Env as CacheEnv } from "../letterboxd/cache/index.js";
+
+export async function onRequest(context: { request: Request; env: CacheEnv }) {
   const { env } = context;
 
   try {


### PR DESCRIPTION
## Summary\n- replace explicit `any` logger and DB bind typings in `functions/letterboxd/compare/index.ts`\n- reduce explicit `any` usage in test utility endpoints (movie lookup/search and tmdb check)\n- tighten watchlist-count cache helper database parameter typings\n\n## Why\nAdds another Sonar-focused remediation batch for remaining explicit-any hotspots in letterboxd compare utilities and supporting test endpoints.\n\n## Validation\n- npm run type-check\n- npx eslint functions/letterboxd/compare/index.ts functions/test/movie-lookup.ts functions/test/movie-search.ts functions/test/tmdb-check.ts functions/letterboxd/watchlist-count/index.ts\n- npm test -- --run functions/__tests__/watchlist-comparison.integration.test.ts\n