### PR TITLE
chore: Version bump to 2.1.5 and tooling / typing hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.5] - 2026-06-10
+
+
 ## [2.1.4] - 2026-05-25
 
 ### Changed
@@ -161,7 +164,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned repository of generated artifacts
 - Removed accidental secrets from repository
 
-[Unreleased]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.4...HEAD
+[Unreleased]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.5...HEAD
+[2.1.5]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.4...v2.1.5
 [2.1.4]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.1...v2.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.5] - 2026-06-10
 
+### Changed
+- Bumped frontend tooling (`vite`, `vitest`, `wrangler`, `lint-staged`)
+- Raised TypeScript compile targets to `ES2022`
+- Introduced stronger Cloudflare D1 types array query responses in letterboxd functions
 
 ## [2.1.4] - 2026-05-25
 

--- a/functions/_lib/common.d.ts
+++ b/functions/_lib/common.d.ts
@@ -6,33 +6,79 @@ export declare const corsHeaders: Record<string, string>;
 
 export declare function withCORS(response: Response): Response;
 
-export declare function jsonResponse(data: any, init?: any): Response;
+export declare function jsonResponse(
+  data: unknown,
+  init?: globalThis.ResponseInit
+): Response;
 
 // Use the global Cache type from DOM lib
 export declare function getCache(): globalThis.Cache | undefined | null;
 
-export declare function kvGetJson(kv: any, key: string): Promise<any | null>;
+export interface KvNamespaceLike {
+  get(key: string, options?: { type?: string }): Promise<unknown>;
+  put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number }
+  ): Promise<void>;
+}
+
+export declare function kvGetJson<T = unknown>(
+  kv: KvNamespaceLike | null | undefined,
+  key: string
+): Promise<T | null>;
 
 export declare function kvPutJson(
-  kv: any,
+  kv: KvNamespaceLike | null | undefined,
   key: string,
-  value: any,
+  value: unknown,
   ttl?: number
 ): Promise<void>;
 
+export interface TmdbEnvLike {
+  TMDB_API_KEY?: string;
+}
+
 export declare function tmdbFetch(
   path: string,
-  env: any,
-  init?: any
+  env: TmdbEnvLike,
+  init?: globalThis.RequestInit
 ): Promise<Response>;
 
-export declare function reduceMovie(m: any): any;
+export interface ReducedMovie {
+  id: unknown;
+  title: unknown;
+  year: number | null;
+  poster_path: string | null;
+  overview: unknown;
+  rating: unknown;
+  runtime: unknown;
+}
 
-export declare function toYear(d: any): number | null;
+export interface TmdbMovieInput {
+  id?: unknown;
+  title?: unknown;
+  release_date?: string | Date | null;
+  poster_path?: string | null;
+  overview?: unknown;
+  vote_average?: unknown;
+  runtime?: unknown;
+}
 
-export declare function isDebug(env?: any): boolean;
+export declare function reduceMovie(m: TmdbMovieInput): ReducedMovie;
 
-export declare function debugLog(env: any, ...args: any[]): void;
+export declare function toYear(
+  d: string | number | Date | null | undefined
+): number | null;
+
+export type DebugEnvLike = object;
+
+export declare function isDebug(env?: DebugEnvLike | null): boolean;
+
+export declare function debugLog(
+  env: DebugEnvLike | null | undefined,
+  ...args: unknown[]
+): void;
 
 // Canonical declarations live in functions/_types/*.d.ts — keep these lightweight
 

--- a/functions/_types/ambient-common.d.ts
+++ b/functions/_types/ambient-common.d.ts
@@ -1,49 +1,141 @@
 // AI Generated: GitHub Copilot - 2025-09-06
 // Explicit ambient declarations for runtime helper import variants
 declare module "../../_lib/common" {
+  export interface KvNamespaceLike {
+    get(key: string, options?: { type?: string }): Promise<unknown>;
+    put(
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number }
+    ): Promise<void>;
+  }
+
+  export interface TmdbEnvLike {
+    TMDB_API_KEY?: string;
+  }
+
+  export interface TmdbMovieInput {
+    id?: unknown;
+    title?: unknown;
+    release_date?: string | Date | null;
+    poster_path?: string | null;
+    overview?: unknown;
+    vote_average?: unknown;
+    runtime?: unknown;
+  }
+
+  export interface ReducedMovie {
+    id: unknown;
+    title: unknown;
+    year: number | null;
+    poster_path: string | null;
+    overview: unknown;
+    rating: unknown;
+    runtime: unknown;
+  }
+
+  export type DebugEnvLike = object;
+
   export const corsHeaders: Record<string, string>;
   export function withCORS(response: Response): Response;
-  export function jsonResponse(data: any, init?: any): Response;
+  export function jsonResponse(
+    data: unknown,
+    init?: globalThis.ResponseInit
+  ): Response;
   export function getCache(): globalThis.Cache | undefined | null;
-  export function kvGetJson(kv: any, key: string): Promise<any | null>;
+  export function kvGetJson<T = unknown>(
+    kv: KvNamespaceLike | null | undefined,
+    key: string
+  ): Promise<T | null>;
   export function kvPutJson(
-    kv: any,
+    kv: KvNamespaceLike | null | undefined,
     key: string,
-    value: any,
+    value: unknown,
     ttl?: number
   ): Promise<void>;
   export function tmdbFetch(
     path: string,
-    env: any,
-    init?: any
+    env: TmdbEnvLike,
+    init?: globalThis.RequestInit
   ): Promise<Response>;
-  export function reduceMovie(m: any): any;
+  export function reduceMovie(m: TmdbMovieInput): ReducedMovie;
   export function parseGenresToNames(genres: unknown): string[] | undefined;
-  export function toYear(d: any): number | null;
-  export function isDebug(env?: any): boolean;
-  export function debugLog(env: any, ...args: any[]): void;
+  export function toYear(
+    d: string | number | Date | null | undefined
+  ): number | null;
+  export function isDebug(env?: DebugEnvLike | null): boolean;
+  export function debugLog(
+    env: DebugEnvLike | null | undefined,
+    ...args: unknown[]
+  ): void;
 }
 
 declare module "../../_lib/common.js" {
+  export interface KvNamespaceLike {
+    get(key: string, options?: { type?: string }): Promise<unknown>;
+    put(
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number }
+    ): Promise<void>;
+  }
+
+  export interface TmdbEnvLike {
+    TMDB_API_KEY?: string;
+  }
+
+  export interface TmdbMovieInput {
+    id?: unknown;
+    title?: unknown;
+    release_date?: string | Date | null;
+    poster_path?: string | null;
+    overview?: unknown;
+    vote_average?: unknown;
+    runtime?: unknown;
+  }
+
+  export interface ReducedMovie {
+    id: unknown;
+    title: unknown;
+    year: number | null;
+    poster_path: string | null;
+    overview: unknown;
+    rating: unknown;
+    runtime: unknown;
+  }
+
+  export type DebugEnvLike = object;
+
   export const corsHeaders: Record<string, string>;
   export function withCORS(response: Response): Response;
-  export function jsonResponse(data: any, init?: any): Response;
+  export function jsonResponse(
+    data: unknown,
+    init?: globalThis.ResponseInit
+  ): Response;
   export function getCache(): globalThis.Cache | undefined | null;
-  export function kvGetJson(kv: any, key: string): Promise<any | null>;
+  export function kvGetJson<T = unknown>(
+    kv: KvNamespaceLike | null | undefined,
+    key: string
+  ): Promise<T | null>;
   export function kvPutJson(
-    kv: any,
+    kv: KvNamespaceLike | null | undefined,
     key: string,
-    value: any,
+    value: unknown,
     ttl?: number
   ): Promise<void>;
   export function tmdbFetch(
     path: string,
-    env: any,
-    init?: any
+    env: TmdbEnvLike,
+    init?: globalThis.RequestInit
   ): Promise<Response>;
-  export function reduceMovie(m: any): any;
+  export function reduceMovie(m: TmdbMovieInput): ReducedMovie;
   export function parseGenresToNames(genres: unknown): string[] | undefined;
-  export function toYear(d: any): number | null;
-  export function isDebug(env?: any): boolean;
-  export function debugLog(env: any, ...args: any[]): void;
+  export function toYear(
+    d: string | number | Date | null | undefined
+  ): number | null;
+  export function isDebug(env?: DebugEnvLike | null): boolean;
+  export function debugLog(
+    env: DebugEnvLike | null | undefined,
+    ...args: unknown[]
+  ): void;
 }

--- a/functions/_types/common-modules.d.ts
+++ b/functions/_types/common-modules.d.ts
@@ -3,29 +3,111 @@
 // so TypeScript recognizes imports like '../../_lib/common' and '../../_lib/common.js'
 
 declare module "*_lib/common" {
-  export function debugLog(env: any, ...args: any[]): void;
-  export function isDebug(env?: any): boolean;
+  export interface KvNamespaceLike {
+    get(key: string, options?: { type?: string }): Promise<unknown>;
+    put(
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number }
+    ): Promise<void>;
+  }
+
+  export interface TmdbEnvLike {
+    TMDB_API_KEY?: string;
+  }
+
+  export interface TmdbMovieInput {
+    id?: unknown;
+    title?: unknown;
+    release_date?: string | Date | null;
+    poster_path?: string | null;
+    overview?: unknown;
+    vote_average?: unknown;
+    runtime?: unknown;
+  }
+
+  export interface ReducedMovie {
+    id: unknown;
+    title: unknown;
+    year: number | null;
+    poster_path: string | null;
+    overview: unknown;
+    rating: unknown;
+    runtime: unknown;
+  }
+
+  export type DebugEnvLike = object;
+
+  export function debugLog(
+    env: DebugEnvLike | null | undefined,
+    ...args: unknown[]
+  ): void;
+  export function isDebug(env?: DebugEnvLike | null): boolean;
   export const corsHeaders: Record<string, string>;
-  export function jsonResponse(data: any, init?: any): Response;
+  export function jsonResponse(
+    data: unknown,
+    init?: globalThis.ResponseInit
+  ): Response;
   export function tmdbFetch(
     path: string,
-    env: any,
-    init?: any
+    env: TmdbEnvLike,
+    init?: globalThis.RequestInit
   ): Promise<Response>;
-  export function reduceMovie(m: any): any;
+  export function reduceMovie(m: TmdbMovieInput): ReducedMovie;
   export function parseGenresToNames(genres: unknown): string[] | undefined;
 }
 
 declare module "*_lib/common.js" {
-  export function debugLog(env: any, ...args: any[]): void;
-  export function isDebug(env?: any): boolean;
+  export interface KvNamespaceLike {
+    get(key: string, options?: { type?: string }): Promise<unknown>;
+    put(
+      key: string,
+      value: string,
+      options?: { expirationTtl?: number }
+    ): Promise<void>;
+  }
+
+  export interface TmdbEnvLike {
+    TMDB_API_KEY?: string;
+  }
+
+  export interface TmdbMovieInput {
+    id?: unknown;
+    title?: unknown;
+    release_date?: string | Date | null;
+    poster_path?: string | null;
+    overview?: unknown;
+    vote_average?: unknown;
+    runtime?: unknown;
+  }
+
+  export interface ReducedMovie {
+    id: unknown;
+    title: unknown;
+    year: number | null;
+    poster_path: string | null;
+    overview: unknown;
+    rating: unknown;
+    runtime: unknown;
+  }
+
+  export type DebugEnvLike = object;
+
+  export function debugLog(
+    env: DebugEnvLike | null | undefined,
+    ...args: unknown[]
+  ): void;
+  export function isDebug(env?: DebugEnvLike | null): boolean;
   export const corsHeaders: Record<string, string>;
-  export function jsonResponse(data: any, init?: any): Response;
+  export function jsonResponse(
+    data: unknown,
+    init?: globalThis.ResponseInit
+  ): Response;
   export function tmdbFetch(
     path: string,
-    env: any,
-    init?: any
+    env: TmdbEnvLike,
+    init?: globalThis.RequestInit
   ): Promise<Response>;
-  export function reduceMovie(m: any): any;
+  export function reduceMovie(m: TmdbMovieInput): ReducedMovie;
   export function parseGenresToNames(genres: unknown): string[] | undefined;
 }

--- a/functions/admin/tmdb-sync/index.ts
+++ b/functions/admin/tmdb-sync/index.ts
@@ -21,7 +21,7 @@ interface TMDBMovie {
   vote_count: number;
   popularity: number;
   adult: boolean;
-  genre_ids: number[];
+  genre_ids?: number[];
   runtime?: number;
   status?: string;
   tagline?: string;
@@ -38,6 +38,28 @@ interface TMDBResponse {
 interface TMDBGenre {
   id: number;
   name: string;
+}
+
+interface TMDBCrewMember {
+  job?: string;
+  name?: string;
+}
+
+interface TMDBMovieDetails extends TMDBMovie {
+  credits?: {
+    crew?: TMDBCrewMember[];
+  };
+  genre_ids?: number[];
+}
+
+interface D1PreparedStatementLike {
+  bind(...values: unknown[]): D1PreparedStatementLike;
+  run(): Promise<unknown>;
+  all<T = Record<string, unknown>>(): Promise<{ results?: T[] }>;
+}
+
+interface D1DatabaseLike {
+  prepare(query: string): D1PreparedStatementLike;
 }
 
 // Note: credits shape is accessed directly from appended details response; no dedicated interface needed
@@ -70,12 +92,13 @@ async function rateLimit() {
   requestCount++;
 }
 
-async function fetchTMDBData(url: string, apiKey: string): Promise<any> {
+async function fetchTMDBData<T = unknown>(
+  url: string,
+  apiKey: string
+): Promise<T> {
   await rateLimit();
 
-  const ControllerCtor = (globalThis as any).AbortController as
-    | (new () => { abort: (reason?: any) => void; signal: any })
-    | undefined;
+  const ControllerCtor = globalThis.AbortController ?? undefined;
   const controller = ControllerCtor ? new ControllerCtor() : undefined;
   const timeout = setTimeout(
     () => controller?.abort("timeout"),
@@ -85,14 +108,16 @@ async function fetchTMDBData(url: string, apiKey: string): Promise<any> {
   try {
     response = await fetch(
       `https://api.themoviedb.org/3${url}${url.includes("?") ? "&" : "?"}api_key=${apiKey}`,
-      controller ? { signal: (controller as any).signal } : undefined
+      controller ? { signal: controller.signal } : undefined
     );
   } catch (e) {
-    throw new Error(
+    const message =
       e instanceof Error && e.name === "AbortError"
         ? `TMDB API timeout after ${TMDB_REQUEST_TIMEOUT_MS}ms for ${url}`
-        : `TMDB API fetch error for ${url}: ${String(e)}`
-    );
+        : `TMDB API fetch error for ${url}: ${String(e)}`;
+    const wrapped = new Error(message) as Error & { cause?: unknown };
+    wrapped.cause = e;
+    throw wrapped;
   } finally {
     clearTimeout(timeout);
   }
@@ -103,27 +128,31 @@ async function fetchTMDBData(url: string, apiKey: string): Promise<any> {
     );
   }
 
-  return response.json();
+  return (await response.json()) as T;
 }
 
 async function getMovieDetails(
   movieId: number,
   apiKey: string
-): Promise<{ movie: any; director: string }> {
+): Promise<{ movie: TMDBMovieDetails; director: string }> {
   // Get movie details and credits in a single request to reduce API calls
-  const movie = await fetchTMDBData(
+  const movie = await fetchTMDBData<TMDBMovieDetails>(
     `/movie/${movieId}?append_to_response=credits`,
     apiKey
   );
   const director =
-    movie.credits?.crew?.find((person: any) => person.job === "Director")
-      ?.name || "Unknown";
+    movie.credits?.crew?.find(
+      (person: TMDBCrewMember) => person.job === "Director"
+    )?.name || "Unknown";
 
   return { movie, director };
 }
 
 async function loadGenresMap(apiKey: string): Promise<Map<number, string>> {
-  const genresData = await fetchTMDBData("/genre/movie/list", apiKey);
+  const genresData = await fetchTMDBData<{ genres: TMDBGenre[] }>(
+    "/genre/movie/list",
+    apiKey
+  );
   const genres: Map<number, string> = new Map();
   genresData.genres.forEach((genre: TMDBGenre) => {
     genres.set(genre.id, genre.name);
@@ -158,7 +187,7 @@ function getReleaseYear(releaseDate?: string | null): number | null {
 }
 
 async function upsertMovie(
-  database: any,
+  database: D1DatabaseLike,
   movieDetails: TMDBMovie,
   director: string,
   finalGenres: string[],
@@ -198,7 +227,7 @@ async function upsertMovie(
 }
 
 async function updateSyncMetadata(
-  database: any,
+  database: D1DatabaseLike,
   key: string,
   value: string
 ): Promise<void> {
@@ -240,7 +269,7 @@ async function fetchDiscoverPage(
 }
 
 async function processPopularResults(options: {
-  database: any;
+  database: D1DatabaseLike;
   apiKey: string;
   results: TMDBMovie[];
   genres: Map<number, string>;
@@ -302,7 +331,7 @@ async function processPopularResults(options: {
 }
 
 async function syncTMDBMoviesByID(
-  database: any,
+  database: D1DatabaseLike,
   apiKey: string,
   startMovieId: number,
   maxMovies: number = 100,
@@ -415,7 +444,7 @@ async function syncTMDBMoviesByID(
 }
 
 async function syncTMDBChanges(
-  database: any,
+  database: D1DatabaseLike,
   apiKey: string,
   startDate?: string,
   sentinel: string = "Unknown"
@@ -434,8 +463,12 @@ async function syncTMDBChanges(
       ? `/movie/changes?start_date=${startDate}`
       : "/movie/changes";
 
-    const changesResponse = await fetchTMDBData(changesUrl, apiKey);
-    const changedMovieIds = changesResponse.results.map((item: any) => item.id);
+    const changesResponse = await fetchTMDBData<{
+      results?: Array<{ id: number }>;
+    }>(changesUrl, apiKey);
+    const changedMovieIds = (changesResponse.results || []).map(
+      (item) => item.id
+    );
 
     debugLog(
       undefined,
@@ -505,7 +538,7 @@ async function syncTMDBChanges(
 }
 
 async function syncTMDBMovies(
-  database: any,
+  database: D1DatabaseLike,
   apiKey: string,
   startPage: number = 1,
   maxPages: number = 10,
@@ -629,7 +662,7 @@ async function syncTMDBMovies(
 }
 
 async function syncTMDBCurrentYear(
-  database: any,
+  database: D1DatabaseLike,
   apiKey: string,
   releaseYearStart: string,
   releaseYearEnd: string,
@@ -702,7 +735,7 @@ async function syncTMDBCurrentYear(
 
 // Backfill genres for existing movies
 async function backfillGenres(
-  database: any,
+  database: D1DatabaseLike,
   apiKey: string,
   options?: { limit?: number; mode?: "missing" | "all" },
   sentinel: string = "Unknown"
@@ -715,7 +748,10 @@ async function backfillGenres(
 
   // Load genre dictionary once for fallback mapping
   const genres: Map<number, string> = await (async () => {
-    const gData = await fetchTMDBData("/genre/movie/list", apiKey);
+    const gData = await fetchTMDBData<{ genres: TMDBGenre[] }>(
+      "/genre/movie/list",
+      apiKey
+    );
     const map = new Map<number, string>();
     gData.genres.forEach((g: TMDBGenre) => map.set(g.id, g.name));
     return map;
@@ -742,7 +778,7 @@ async function backfillGenres(
       )
       .bind(afterId, size)
       .all();
-    return ((res?.results as any[]) || []) as Array<{ id: number }>;
+    return (res?.results || []) as Array<{ id: number }>;
   };
 
   const fetchNames = async (movieId: number): Promise<string[]> => {

--- a/functions/api/watchlist-comparison/index.ts
+++ b/functions/api/watchlist-comparison/index.ts
@@ -591,9 +591,8 @@ const reportTmdbCatalogCount = async (env: Env, debugInfo: DebugInfo) => {
   try {
     const countRes = await env.MOVIES_DB.prepare(
       `SELECT COUNT(*) as c FROM tmdb_movies`
-    ).first();
-    debugInfo.db.tmdb_catalog_count =
-      (countRes && (countRes.c || countRes["c"])) || 0;
+    ).first<{ c?: number }>();
+    debugInfo.db.tmdb_catalog_count = Number(countRes?.c ?? 0);
   } catch (err) {
     debugInfo.db.tmdb_catalog_count = null;
     debugLog(

--- a/functions/api/watchlist-comparison/index.ts
+++ b/functions/api/watchlist-comparison/index.ts
@@ -610,7 +610,7 @@ const enhanceCommonMovies = async (
 ) => {
   const { isDebug } = await import("../../_lib/common");
   const debugMatchingFlag = (env as EnvWithDebugMatching).DEBUG_MATCHING;
-  const enableMatchingDebug = Boolean(isDebug(env) || debugMatchingFlag);
+  const enableMatchingDebug = Boolean(isDebug(env) || debugMatchingFlag === true || debugMatchingFlag === "true");
   const enhancedMovies = await enhanceWithTMDBData(
     commonMovies,
     env,

--- a/functions/api/watchlist-comparison/index.ts
+++ b/functions/api/watchlist-comparison/index.ts
@@ -45,6 +45,75 @@ interface ComparisonRequestBody {
   usernames?: string[]; // Legacy support
 }
 
+interface ScrapingResult {
+  count: number;
+  timeMs: number;
+  success: boolean;
+  error?: string;
+  errorType?: string;
+  stack?: string;
+}
+
+interface MatchingInfo {
+  totalUnique: number;
+  commonCount: number;
+  commonMovies: Array<{ title: string; year: number; users: string[] }>;
+  candidates?: Record<string, Record<string, TmdbCandidateDebug[]>>;
+}
+
+interface DebugInfo {
+  requestReceived: {
+    usernames: string[];
+    timestamp: string;
+  };
+  scrapingResults: Record<string, ScrapingResult>;
+  movieCounts: Record<string, number>;
+  sampleMovies: Record<string, Array<{ title: string; year: number }>>;
+  matchingInfo: MatchingInfo;
+  db: {
+    tmdb_catalog_count: number | null;
+    enrichment_hits: number;
+    enrichment_misses: number;
+  };
+  enrichment?: {
+    sourceCounts: Record<string, number>;
+  };
+}
+
+interface TmdbRow {
+  id: number | string;
+  title: string;
+  original_title: string | null;
+  year: number | string | null;
+  release_date: string | null;
+  poster_path: string | null;
+  overview: string | null;
+  vote_average: number | null;
+  director: string | null;
+  runtime: number | null;
+  genres: unknown;
+  popularity: number | null;
+}
+
+interface WatchlistScrapeResult {
+  username: string;
+  movies: LetterboxdMovie[];
+  duration: number;
+}
+
+type EnvWithDebugMatching = Env & {
+  DEBUG_MATCHING?: unknown;
+};
+
+interface D1QueryResult<T> {
+  results?: T[];
+}
+
+type TmdbCandidateDebug = Pick<
+  TmdbRow,
+  "id" | "title" | "original_title" | "year" | "popularity"
+>;
+
 const replaceAllSafe = (
   input: string,
   pattern: RegExp | string,
@@ -421,7 +490,7 @@ const initDebugInfo = (usernames: string[]) => ({
 const scrapeAllWatchlists = async (
   usernames: string[],
   env: Env,
-  debugInfo: any
+  debugInfo: DebugInfo
 ) => {
   const watchlistPromises = usernames.map(async (username, index) => {
     const baseDelay = 500; // Start with 500ms
@@ -482,7 +551,7 @@ const scrapeAllWatchlists = async (
   ]);
 };
 
-const logWatchlistSamples = (watchlists: any[], env: Env) => {
+const logWatchlistSamples = (watchlists: WatchlistScrapeResult[], env: Env) => {
   watchlists.forEach((watchlist) => {
     debugLog(
       env,
@@ -505,7 +574,7 @@ const logWatchlistSamples = (watchlists: any[], env: Env) => {
 const updateMatchingDebug = (
   watchlists: { username: string; movies: LetterboxdMovie[] }[],
   commonMovies: CommonMovie[],
-  debugInfo: any
+  debugInfo: DebugInfo
 ) => {
   debugInfo.matchingInfo.totalUnique = new Set(
     watchlists.flatMap((w) => w.movies.map((m) => `${m.title}-${m.year}`))
@@ -518,7 +587,7 @@ const updateMatchingDebug = (
   }));
 };
 
-const reportTmdbCatalogCount = async (env: Env, debugInfo: any) => {
+const reportTmdbCatalogCount = async (env: Env, debugInfo: DebugInfo) => {
   try {
     const countRes = await env.MOVIES_DB.prepare(
       `SELECT COUNT(*) as c FROM tmdb_movies`
@@ -538,12 +607,11 @@ const reportTmdbCatalogCount = async (env: Env, debugInfo: any) => {
 const enhanceCommonMovies = async (
   commonMovies: CommonMovie[],
   env: Env,
-  debugInfo: any
+  debugInfo: DebugInfo
 ) => {
   const { isDebug } = await import("../../_lib/common");
-  const enableMatchingDebug = Boolean(
-    isDebug(env) || (env && (env as any).DEBUG_MATCHING)
-  );
+  const debugMatchingFlag = (env as EnvWithDebugMatching).DEBUG_MATCHING;
+  const enableMatchingDebug = Boolean(isDebug(env) || debugMatchingFlag);
   const enhancedMovies = await enhanceWithTMDBData(
     commonMovies,
     env,
@@ -557,7 +625,7 @@ const enhanceCommonMovies = async (
 
 const updateEnrichmentStats = (
   enhancedMovies: Movie[],
-  debugInfo: any,
+  debugInfo: DebugInfo,
   env: Env
 ) => {
   try {
@@ -639,13 +707,13 @@ export function findCommonMovies(
 export async function enhanceWithTMDBData(
   movies: CommonMovie[],
   env: Env,
-  debugInfo?: any
+  debugInfo?: DebugInfo
 ): Promise<Movie[]> {
   if (movies.length === 0) return [];
   const BATCH = 10;
   const out: Movie[] = [];
 
-  const mapTmdb = (row: any, base: CommonMovie, source: string): Movie => {
+  const mapTmdb = (row: TmdbRow, base: CommonMovie, source: string): Movie => {
     // Parse genres via shared helper
     const gnames = parseGenresToNames(row.genres);
     const genres: string[] | undefined = gnames ? [...gnames] : undefined;
@@ -668,7 +736,7 @@ export async function enhanceWithTMDBData(
     };
   };
 
-  const mapRowsForDebug = (rows: any[] | undefined) =>
+  const mapRowsForDebug = (rows: TmdbRow[] | undefined): TmdbCandidateDebug[] =>
     (rows || []).map((r) => ({
       id: r.id,
       title: r.title,
@@ -694,59 +762,57 @@ export async function enhanceWithTMDBData(
         debugInfo.matchingInfo.candidates[key] || {};
     }
 
+    const setCandidateDebug = (
+      strategy: string,
+      rows: TmdbRow[] | undefined
+    ) => {
+      const bucket = debugInfo?.matchingInfo?.candidates?.[key];
+      if (!bucket) return;
+      bucket[strategy] = mapRowsForDebug(rows);
+    };
+
     const exactWithYear = async () => {
-      const res = await env.MOVIES_DB.prepare(
+      const res = (await env.MOVIES_DB.prepare(
         `SELECT * FROM tmdb_movies WHERE (LOWER(title)=LOWER(?) OR LOWER(original_title)=LOWER(?)) AND (? = 0 OR year IS NULL OR abs(year - ?) <= 1) ORDER BY popularity DESC LIMIT 1`
       )
         .bind(title, title, year, year)
-        .all();
-      if (debugInfo?.matchingInfo)
-        debugInfo.matchingInfo.candidates[key].exactWithYear = mapRowsForDebug(
-          res.results
-        );
+        .all()) as D1QueryResult<TmdbRow>;
+      setCandidateDebug("exactWithYear", res.results);
       return res.results?.[0] ?? null;
     };
 
     const likeWithYear = async () => {
-      const res = await env.MOVIES_DB.prepare(
+      const res = (await env.MOVIES_DB.prepare(
         `SELECT * FROM tmdb_movies WHERE (title LIKE ? OR original_title LIKE ?) AND (? = 0 OR year IS NULL OR abs(year - ?) <= 1) ORDER BY popularity DESC LIMIT 1`
       )
         .bind(`%${title}%`, `%${title}%`, year, year)
-        .all();
-      if (debugInfo?.matchingInfo)
-        debugInfo.matchingInfo.candidates[key].likeWithYear = mapRowsForDebug(
-          res.results
-        );
+        .all()) as D1QueryResult<TmdbRow>;
+      setCandidateDebug("likeWithYear", res.results);
       return res.results?.[0] ?? null;
     };
 
     const exactNoYear = async () => {
-      const res = await env.MOVIES_DB.prepare(
+      const res = (await env.MOVIES_DB.prepare(
         `SELECT * FROM tmdb_movies WHERE LOWER(title)=LOWER(?) OR LOWER(original_title)=LOWER(?) ORDER BY popularity DESC LIMIT 1`
       )
         .bind(title, title)
-        .all();
-      if (debugInfo?.matchingInfo)
-        debugInfo.matchingInfo.candidates[key].exactNoYear = mapRowsForDebug(
-          res.results
-        );
+        .all()) as D1QueryResult<TmdbRow>;
+      setCandidateDebug("exactNoYear", res.results);
       return res.results?.[0] ?? null;
     };
 
     const likeNoYear = async () => {
-      const res = await env.MOVIES_DB.prepare(
+      const res = (await env.MOVIES_DB.prepare(
         `SELECT * FROM tmdb_movies WHERE title LIKE ? OR original_title LIKE ? ORDER BY popularity DESC LIMIT 5`
       )
         .bind(`%${title}%`, `%${title}%`)
-        .all();
+        .all()) as D1QueryResult<TmdbRow>;
       const candidates = res.results || [];
-      if (debugInfo?.matchingInfo)
-        debugInfo.matchingInfo.candidates[key].likeNoYear =
-          mapRowsForDebug(candidates);
+      setCandidateDebug("likeNoYear", candidates);
       if (candidates.length === 0) return null;
       const want = normalizeTitle(title);
       const wantYear = year || 0;
-      let best: any = null;
+      let best: TmdbRow | null = null;
       let bestScore = -Infinity;
       for (const c of candidates) {
         const ct = normalizeTitle(String(c.title || c.original_title || ""));
@@ -790,7 +856,7 @@ export async function enhanceWithTMDBData(
             friendCount: m.friendCount,
             friendList: m.friendList,
             source: "fallback",
-          } as Movie;
+          };
         } catch (err) {
           console.error("Enhancement error for", m.title, err);
           return {
@@ -801,7 +867,7 @@ export async function enhanceWithTMDBData(
             friendCount: m.friendCount,
             friendList: m.friendList,
             source: "fallback",
-          } as Movie;
+          };
         }
       })
     );
@@ -841,7 +907,7 @@ export async function onRequestPost(context: { request: Request; env: Env }) {
 
     debugLog(env, `Starting comparison for: ${usernames.join(", ")}`);
 
-    const debugInfo: any = initDebugInfo(usernames);
+    const debugInfo: DebugInfo = initDebugInfo(usernames);
 
     // AI Generated: GitHub Copilot - 2025-08-29T12:15:00Z
     // Performance Optimization: Smart Rate Limiting - Optimized parallel scraping with intelligent delays

--- a/functions/api/watchlist-count-updates/index.ts
+++ b/functions/api/watchlist-count-updates/index.ts
@@ -99,7 +99,10 @@ function checkRateLimit(
 }
 
 // Validate payload structure and values
-function validatePayload(payload: any): { valid: boolean; errors: string[] } {
+function validatePayload(payload: unknown): {
+  valid: boolean;
+  errors: string[];
+} {
   const errors: string[] = [];
 
   if (typeof payload !== "object" || payload === null) {
@@ -107,46 +110,48 @@ function validatePayload(payload: any): { valid: boolean; errors: string[] } {
     return { valid: false, errors };
   }
 
+  const candidate = payload as Partial<UpdatePayload>;
+
   // Required fields
-  if (typeof payload.username !== "string" || !payload.username.trim()) {
+  if (typeof candidate.username !== "string" || !candidate.username.trim()) {
     errors.push("username is required and must be a non-empty string");
   }
 
-  if (typeof payload.count !== "number") {
+  if (typeof candidate.count !== "number") {
     errors.push("count is required and must be a number");
-  } else if (payload.count < 0) {
+  } else if (candidate.count < 0) {
     errors.push("count must be >= 0");
-  } else if (!Number.isInteger(payload.count)) {
+  } else if (!Number.isInteger(candidate.count)) {
     errors.push("count must be an integer");
   }
 
   // Optional fields validation
-  if (payload.etag !== undefined && typeof payload.etag !== "string") {
+  if (candidate.etag !== undefined && typeof candidate.etag !== "string") {
     errors.push("etag must be a string if provided");
   }
 
-  if (payload.lastFetchedAt !== undefined) {
-    if (typeof payload.lastFetchedAt !== "number") {
-      errors.push("lastFetchedAt must be a number if provided");
-    } else {
+  if (candidate.lastFetchedAt !== undefined) {
+    if (typeof candidate.lastFetchedAt === "number") {
       const now = Date.now();
       const maxAge = 7 * 24 * 60 * 60 * 1000; // 7 days
       if (
-        payload.lastFetchedAt > now + 60000 ||
-        payload.lastFetchedAt < now - maxAge
+        candidate.lastFetchedAt > now + 60000 ||
+        candidate.lastFetchedAt < now - maxAge
       ) {
         errors.push("lastFetchedAt timestamp is unreasonable");
       }
+    } else {
+      errors.push("lastFetchedAt must be a number if provided");
     }
   }
 
-  if (payload.source !== undefined && payload.source !== "client") {
+  if (candidate.source !== undefined && candidate.source !== "client") {
     errors.push('source must be "client" if provided');
   }
 
   // Username sanitization
-  if (typeof payload.username === "string") {
-    const username = payload.username.trim();
+  if (typeof candidate.username === "string") {
+    const username = candidate.username.trim();
     if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
       errors.push("username contains invalid characters");
     }

--- a/functions/compare/index.ts
+++ b/functions/compare/index.ts
@@ -85,9 +85,11 @@ async function scrapeLetterboxdWatchlist(
     return movies;
   } catch (error) {
     console.error(`Error scraping ${username}:`, error);
-    throw new Error(
+    const err = new Error(
       `Failed to scrape watchlist for ${username}. Make sure the username exists and the watchlist is public.`
     );
+    err.cause = error;
+    throw err;
   }
 }
 
@@ -98,6 +100,18 @@ async function scrapeLetterboxdWatchlist(
 interface CommonMovie extends LetterboxdMovie {
   friendCount: number;
   friendList: string[];
+}
+
+interface TmdbMovieRow {
+  id: number;
+  title: string;
+  year?: number;
+  poster_path?: string;
+  overview?: string;
+  vote_average?: number;
+  director?: string;
+  runtime?: number;
+  genres?: unknown;
 }
 
 // Find movies that appear in multiple watchlists using efficient set operations
@@ -227,7 +241,7 @@ async function enhanceWithTMDBData(
         const result = await stmt.all();
 
         if (result.results && result.results.length > 0) {
-          const tmdbMovie: any = result.results[0];
+          const tmdbMovie = result.results[0] as TmdbMovieRow;
 
           // Parse genres from D1 row (stored as JSON text or array)
           let genres: string[] | undefined;

--- a/functions/compare/index.ts
+++ b/functions/compare/index.ts
@@ -241,7 +241,7 @@ async function enhanceWithTMDBData(
         const result = await stmt.all();
 
         if (result.results && result.results.length > 0) {
-          const tmdbMovie = result.results[0] as TmdbMovieRow;
+          const tmdbMovie = result.results[0] as unknown as TmdbMovieRow;
 
           // Parse genres from D1 row (stored as JSON text or array)
           let genres: string[] | undefined;

--- a/functions/letterboxd/avatar-proxy/index.ts
+++ b/functions/letterboxd/avatar-proxy/index.ts
@@ -37,7 +37,7 @@ function isValidLetterboxdUrl(url: string): boolean {
 export async function onRequest(context: {
   request: Request;
   env: {
-    MOVIES_DB: any; // D1Database type
+    MOVIES_DB: unknown;
   };
 }) {
   // Set CORS headers

--- a/functions/letterboxd/cache/index.ts
+++ b/functions/letterboxd/cache/index.ts
@@ -6,8 +6,19 @@
 
 import { debugLog } from "../../_lib/common";
 
+export interface D1PreparedStatementLike {
+  bind(...values: unknown[]): D1PreparedStatementLike;
+  first<T = Record<string, unknown>>(): Promise<T | null>;
+  all<T = Record<string, unknown>>(): Promise<{ results: T[] }>;
+  run(): Promise<{ meta: { changes: number } }>;
+}
+
+export interface D1DatabaseLike {
+  prepare(query: string): D1PreparedStatementLike;
+}
+
 export interface Env {
-  MOVIES_DB: any; // D1Database type
+  MOVIES_DB: D1DatabaseLike;
   TMDB_API_KEY: string;
   UPSTASH_REDIS_REST_URL?: string;
   UPSTASH_REDIS_REST_TOKEN?: string;
@@ -216,7 +227,7 @@ export async function onRequestPost(context: { request: Request; env: Env }) {
 }
 
 async function getCachedFriends(
-  database: any,
+  database: D1DatabaseLike,
   username: string
 ): Promise<FriendsCache | null> {
   try {
@@ -229,7 +240,11 @@ async function getCachedFriends(
     `
       )
       .bind(username)
-      .first();
+      .first<{
+        friends_data: string;
+        last_updated: number;
+        expires_at: number;
+      }>();
 
     if (!result) {
       return null;
@@ -242,16 +257,13 @@ async function getCachedFriends(
       expiresAt: result.expires_at,
     };
   } catch (error) {
-    debugLog(
-      undefined as any,
-      `Error getting cached friends: ${String(error)}`
-    );
+    debugLog(undefined, `Error getting cached friends: ${String(error)}`);
     return null;
   }
 }
 
 async function setCachedFriends(
-  database: any,
+  database: D1DatabaseLike,
   username: string,
   friends: FriendLike[] | CachedFriend[],
   env?: Env
@@ -263,14 +275,15 @@ async function setCachedFriends(
     // Normalize to CachedFriend[] by ensuring lastUpdated is present. This
     // allows callers to pass either the raw scraped friend objects or already
     // annotated CachedFriend objects.
+    type FriendCacheInput = FriendLike & { lastUpdated?: number };
     const normalizedFriends: CachedFriend[] = (
-      friends as (FriendLike | CachedFriend)[]
+      friends as FriendCacheInput[]
     ).map((f) => ({
       username: f.username,
-      displayName: (f as any).displayName,
-      watchlistCount: (f as any).watchlistCount,
-      profileImageUrl: (f as any).profileImageUrl,
-      lastUpdated: (f as any).lastUpdated ?? now,
+      displayName: f.displayName,
+      watchlistCount: f.watchlistCount,
+      profileImageUrl: f.profileImageUrl,
+      lastUpdated: f.lastUpdated ?? now,
     }));
 
     await database
@@ -286,7 +299,7 @@ async function setCachedFriends(
 
     debugLog(env, `Cached ${normalizedFriends.length} friends for ${username}`);
   } catch (error) {
-    debugLog(env as any, `Error caching friends: ${String(error)}`);
+    debugLog(env, `Error caching friends: ${String(error)}`);
     // Don't throw - caching is not critical
   }
 }
@@ -337,7 +350,7 @@ export async function getCount(
     // Fallback to D1
     return await getCountFromD1(username, env);
   } catch (error) {
-    debugLog(env as any, `Error getting cached count: ${String(error)}`);
+    debugLog(env, `Error getting cached count: ${String(error)}`);
     return null;
   }
 }
@@ -369,7 +382,7 @@ export async function setCount(
     // Also store in D1 as backup
     await setCountInD1(username, payload, env);
   } catch (error) {
-    debugLog(env as any, `Error setting cached count: ${String(error)}`);
+    debugLog(env, `Error setting cached count: ${String(error)}`);
     throw error;
   }
 }
@@ -416,7 +429,7 @@ export async function acquireLock(
     // Handle both "OK" response and numeric response (1 for success, 0 for failure)
     return result.result === "OK" || result.result === 1;
   } catch (error) {
-    debugLog(env as any, `Error acquiring Redis lock: ${String(error)}`);
+    debugLog(env, `Error acquiring Redis lock: ${String(error)}`);
     // Fallback to D1
     return await acquireLockD1(username, timeoutMs, env);
   }
@@ -449,7 +462,7 @@ export async function releaseLock(username: string, env: Env): Promise<void> {
       throw new Error(`Redis request failed: ${response.status}`);
     }
   } catch (error) {
-    debugLog(env as any, `Error releasing Redis lock: ${String(error)}`);
+    debugLog(env, `Error releasing Redis lock: ${String(error)}`);
     // Fallback to D1
     await releaseLockD1(username, env);
   }
@@ -498,7 +511,7 @@ async function getCountFromRedis(
 
     return data;
   } catch (error) {
-    debugLog(env as any, `Error getting count from Redis: ${String(error)}`);
+    debugLog(env, `Error getting count from Redis: ${String(error)}`);
     return null;
   }
 }
@@ -527,7 +540,7 @@ async function setCountInRedis(
       throw new Error(`Redis set failed: ${response.status}`);
     }
   } catch (error) {
-    debugLog(env as any, `Error setting count in Redis: ${String(error)}`);
+    debugLog(env, `Error setting count in Redis: ${String(error)}`);
     throw error;
   }
 }
@@ -542,7 +555,7 @@ async function getCountFromD1(
       "SELECT value, expires_at FROM watchlist_counts_cache WHERE username = ?"
     )
       .bind(username)
-      .first();
+      .first<{ value: string; expires_at: number }>();
 
     if (!result) {
       return null;
@@ -555,7 +568,7 @@ async function getCountFromD1(
 
     return JSON.parse(result.value);
   } catch (error) {
-    debugLog(env as any, `Error getting count from D1: ${String(error)}`);
+    debugLog(env, `Error getting count from D1: ${String(error)}`);
     return null;
   }
 }
@@ -577,7 +590,7 @@ async function setCountInD1(
       .bind(username, JSON.stringify(payload), expiresAt)
       .run();
   } catch (error) {
-    debugLog(env as any, `Error setting count in D1: ${String(error)}`);
+    debugLog(env, `Error setting count in D1: ${String(error)}`);
     throw error;
   }
 }
@@ -599,7 +612,7 @@ async function acquireLockD1(
 
     return result.meta.changes > 0; // True if inserted (lock acquired)
   } catch (error) {
-    debugLog(env as any, `Error acquiring D1 lock: ${String(error)}`);
+    debugLog(env, `Error acquiring D1 lock: ${String(error)}`);
     return false;
   }
 }
@@ -612,6 +625,6 @@ async function releaseLockD1(username: string, env: Env): Promise<void> {
       .bind(lockKey)
       .run();
   } catch (error) {
-    debugLog(env as any, `Error releasing D1 lock: ${String(error)}`);
+    debugLog(env, `Error releasing D1 lock: ${String(error)}`);
   }
 }

--- a/functions/letterboxd/compare/index.ts
+++ b/functions/letterboxd/compare/index.ts
@@ -6,7 +6,7 @@ import type { Env as CacheEnv } from "../cache/index.js";
 
 // Structured logging utility for production
 const logger = {
-  info: (message: string, meta?: any) => {
+  info: (message: string, meta?: unknown) => {
     debugLog(
       undefined,
       JSON.stringify({
@@ -17,17 +17,17 @@ const logger = {
       })
     );
   },
-  error: (message: string, error?: any) => {
+  error: (message: string, error?: unknown) => {
     console.error(
       JSON.stringify({
         level: "error",
         message,
-        error: error?.message || error,
+        error: error instanceof Error ? error.message : String(error ?? ""),
         timestamp: new Date().toISOString(),
       })
     );
   },
-  warn: (message: string, meta?: any) => {
+  warn: (message: string, meta?: unknown) => {
     debugLog(
       undefined,
       JSON.stringify({
@@ -61,6 +61,18 @@ interface Movie {
   letterboxdSlug?: string | null;
   friendCount: number;
   friendList: string[];
+}
+
+interface TmdbRow {
+  id: number;
+  title: string;
+  year?: number;
+  poster_path?: string | null;
+  overview?: string | null;
+  vote_average?: number | null;
+  director?: string | null;
+  runtime?: number | null;
+  genres?: unknown;
 }
 
 function decodeHTMLEntities(text: string): string {
@@ -280,10 +292,10 @@ async function enhanceWithTMDBData(
            ORDER BY popularity DESC
            LIMIT 1`;
       const stmt = env.MOVIES_DB.prepare(sql);
-      const binds = anyYear
+      const binds: unknown[] = anyYear
         ? ["'", titleStripped, "'", titleStripped]
         : ["'", titleStripped, "'", titleStripped, year, year - 1, year + 1];
-      return await stmt.bind(...(binds as any)).all();
+      return await stmt.bind(...binds).all();
     } catch (e) {
       debugLog(env, `Stripped REPLACE lookup failed: ${String(e)}`);
       return null;
@@ -310,10 +322,10 @@ async function enhanceWithTMDBData(
            ORDER BY popularity DESC
            LIMIT 1`;
       const stmt = env.MOVIES_DB.prepare(sql);
-      const binds = anyYear
+      const binds: unknown[] = anyYear
         ? [title, title]
         : [title, title, year, year - 1, year + 1];
-      return await stmt.bind(...(binds as any)).all();
+      return await stmt.bind(...binds).all();
     } catch (e) {
       debugLog(env, `Exact lookup failed: ${String(e)}`);
       return null;
@@ -369,11 +381,11 @@ async function enhanceWithTMDBData(
   }
 
   function buildMovieFromRow(
-    r: any,
+    r: TmdbRow,
     movie: LetterboxdMovie & { friendCount: number; friendList: string[] }
   ): Movie {
     // Parse genres via shared helper
-    const gnames = parseGenresToNames((r as any).genres);
+    const gnames = parseGenresToNames(r.genres);
     const genres: string[] | null = gnames ? [...gnames] : null;
     return {
       id: r.id,
@@ -400,7 +412,7 @@ async function enhanceWithTMDBData(
       if (stripped) {
         const strippedResult = await dbFindStripped(stripped, movie.year);
         if (strippedResult?.results?.length)
-          return buildMovieFromRow(strippedResult.results[0], movie);
+          return buildMovieFromRow(strippedResult.results[0] as unknown as TmdbRow, movie);
       }
 
       let searchTitle = normalized;
@@ -437,7 +449,7 @@ async function enhanceWithTMDBData(
       }
 
       if (result?.results?.length)
-        return buildMovieFromRow(result.results[0], movie);
+        return buildMovieFromRow(result.results[0] as unknown as TmdbRow, movie);
 
       return {
         id: generateFallbackId(normalized, movie.year),

--- a/functions/letterboxd/friends/index.ts
+++ b/functions/letterboxd/friends/index.ts
@@ -7,13 +7,17 @@
 // Import cache functions and shared Env type to keep types consistent
 import { getCount } from "../cache/index.js";
 import { debugLog } from "../../_lib/common";
-import type { Env as CacheEnv } from "../cache/index.js";
+import type { Env as CacheEnv, D1DatabaseLike } from "../cache/index.js";
 
 interface Friend {
   username: string;
   displayName?: string;
   watchlistCount?: number;
   profileImageUrl?: string;
+}
+
+interface ClientWatchlistEntry {
+  count?: number;
 }
 
 // Rate limiting - 1 second between requests
@@ -190,7 +194,7 @@ export async function scrapeLetterboxdFriends(
     debugLog(env, `Found ${friends.length} friends for ${username}`);
     return friends;
   } catch (error) {
-    debugLog(env as any, `Error scraping Letterboxd friends: ${String(error)}`);
+    debugLog(env, `Error scraping Letterboxd friends: ${String(error)}`);
     throw error;
   }
 }
@@ -367,7 +371,7 @@ export async function onRequestPost(context: {
 // Watchlist count attachment logic
 async function attachWatchlistCounts(
   friends: Friend[],
-  clientWatchlistCache: any,
+  clientWatchlistCache: Record<string, ClientWatchlistEntry> | undefined,
   env: CacheEnv
 ): Promise<Friend[]> {
   const friendsWithCounts = [];
@@ -409,7 +413,7 @@ async function attachWatchlistCounts(
 const CACHE_DURATION_MS = 6 * 60 * 60 * 1000; // 6 hours
 
 async function getCachedFriends(
-  database: any,
+  database: D1DatabaseLike,
   username: string
 ): Promise<{
   friends: Friend[];
@@ -426,7 +430,11 @@ async function getCachedFriends(
     `
       )
       .bind(username)
-      .first();
+      .first<{
+        friends_data: string;
+        last_updated: number;
+        expires_at: number;
+      }>();
 
     if (!result) {
       return null;
@@ -444,7 +452,7 @@ async function getCachedFriends(
 }
 
 async function setCachedFriends(
-  database: any,
+  database: D1DatabaseLike,
   username: string,
   friends: Friend[],
   env?: CacheEnv

--- a/functions/letterboxd/watchlist-count/index.ts
+++ b/functions/letterboxd/watchlist-count/index.ts
@@ -13,6 +13,16 @@ interface WatchlistCount {
   lastUpdated: number;
 }
 
+interface D1PreparedStatementLike {
+  bind(...values: unknown[]): D1PreparedStatementLike;
+  first<T = Record<string, unknown>>(): Promise<T | null>;
+  run(): Promise<{ meta: { changes: number } }>;
+}
+
+interface D1DatabaseLike {
+  prepare(query: string): D1PreparedStatementLike;
+}
+
 // Rate limiting - 1 second between requests to be respectful to Letterboxd
 let lastRequestTime = 0;
 const RATE_LIMIT_MS = 1000;
@@ -367,7 +377,7 @@ export async function onRequestPost(context: {
 
 // Cache management functions
 async function getCachedWatchlistCount(
-  database: any,
+  database: D1DatabaseLike,
   username: string
 ): Promise<WatchlistCount | null> {
   try {
@@ -380,7 +390,11 @@ async function getCachedWatchlistCount(
     `
       )
       .bind(username)
-      .first();
+      .first<{
+        username: string;
+        watchlist_count: number;
+        last_updated: number;
+      }>();
 
     if (!result) {
       return null;
@@ -398,7 +412,7 @@ async function getCachedWatchlistCount(
 }
 
 async function setCachedWatchlistCount(
-  database: any,
+  database: D1DatabaseLike,
   username: string,
   count: number,
   env?: CacheEnv

--- a/functions/letterboxd/watchlist-count/index.ts
+++ b/functions/letterboxd/watchlist-count/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { debugLog } from "../../_lib/common";
+import type { D1DatabaseLike } from "../cache/index.js";
 import type { Env as CacheEnv } from "../cache/index.js";
 
 interface WatchlistCount {
@@ -13,15 +14,6 @@ interface WatchlistCount {
   lastUpdated: number;
 }
 
-interface D1PreparedStatementLike {
-  bind(...values: unknown[]): D1PreparedStatementLike;
-  first<T = Record<string, unknown>>(): Promise<T | null>;
-  run(): Promise<{ meta: { changes: number } }>;
-}
-
-interface D1DatabaseLike {
-  prepare(query: string): D1PreparedStatementLike;
-}
 
 // Rate limiting - 1 second between requests to be respectful to Letterboxd
 let lastRequestTime = 0;

--- a/functions/search/index.ts
+++ b/functions/search/index.ts
@@ -16,6 +16,36 @@ interface KVNamespace {
 // Extend the canonical CacheEnv with the KV namespace used by this function
 type Env = CacheEnv & { MOVIES_KV: KVNamespace };
 
+interface SearchRow {
+  id: number;
+  title: string;
+  year?: number | null;
+  poster_path?: string | null;
+  overview?: string | null;
+  vote_average?: number | null;
+  director?: string | null;
+  runtime?: number | null;
+}
+
+interface SearchCountRow {
+  total?: number;
+}
+
+interface TmdbSearchMovie {
+  id: number;
+  title: string;
+  release_date?: string;
+  poster_path?: string | null;
+  overview?: string;
+  vote_average?: number;
+  runtime?: number;
+}
+
+interface TmdbSearchResponse {
+  results?: TmdbSearchMovie[];
+  total_pages?: number;
+}
+
 // Temporarily unused interface - commenting out to fix lint warnings
 // interface MovieSearchResult { ... }
 
@@ -35,7 +65,8 @@ export async function onRequestGet(context: { request: Request; env: Env }) {
       .bind(`%${q}%`, `%${q}%`)
       .all();
 
-    const totalRecords = (countResult.results?.[0] as any)?.total || 0;
+    const totalRecords =
+      (countResult.results?.[0] as SearchCountRow)?.total || 0;
 
     const localResults = await env.MOVIES_DB.prepare(
       `SELECT * FROM tmdb_movies WHERE title LIKE ? OR original_title LIKE ? ORDER BY popularity DESC LIMIT ? OFFSET ?`
@@ -44,7 +75,7 @@ export async function onRequestGet(context: { request: Request; env: Env }) {
       .all();
 
     if (localResults.results && localResults.results.length > 0) {
-      const movies = (localResults.results as any[]).map((movie) => ({
+      const movies = (localResults.results as SearchRow[]).map((movie) => ({
         id: movie.id,
         title: movie.title,
         year: movie.year,
@@ -74,8 +105,8 @@ export async function onRequestGet(context: { request: Request; env: Env }) {
   if (!response.ok)
     return Response.json({ error: "tmdb_error" }, { status: 502 });
 
-  const data = await response.json();
-  const movies = (data.results || []).map((movie: any) => ({
+  const data = (await response.json()) as TmdbSearchResponse;
+  const movies = (data.results || []).map((movie) => ({
     id: movie.id,
     title: movie.title,
     year: movie.release_date

--- a/functions/search/index.ts
+++ b/functions/search/index.ts
@@ -75,7 +75,7 @@ export async function onRequestGet(context: { request: Request; env: Env }) {
       .all();
 
     if (localResults.results && localResults.results.length > 0) {
-      const movies = (localResults.results as SearchRow[]).map((movie) => ({
+      const movies = (localResults.results as unknown as SearchRow[]).map((movie) => ({
         id: movie.id,
         title: movie.title,
         year: movie.year,

--- a/functions/test/movie-lookup.ts
+++ b/functions/test/movie-lookup.ts
@@ -5,6 +5,14 @@ import type { Env as CacheEnv } from "../letterboxd/cache/index.js";
 import { debugLog } from "../_lib/common";
 type Env = CacheEnv;
 
+interface TmdbLookupRow {
+  title?: string;
+  original_title?: string;
+  year?: number;
+  release_date?: string | null;
+  popularity?: number;
+}
+
 function normalizeTitle(t: string) {
   return t
     .toLowerCase()
@@ -68,11 +76,11 @@ async function findTmdbRowForMovie(title: string, year: number, env: Env) {
   )
     .bind(`%${t}%`, `%${t}%`)
     .all();
-  const candidates = (res.results || []) as any[];
+  const candidates = (res.results || []) as TmdbLookupRow[];
   if (candidates.length > 0) {
     const want = normalizeTitle(t);
     const wantYear = y || 0;
-    let best: any = null;
+    let best: TmdbLookupRow | null = null;
     let bestScore = -Infinity;
     for (const c of candidates) {
       const ct = normalizeTitle(String(c.title || c.original_title || ""));
@@ -125,7 +133,7 @@ export async function onRequestGet(context: { request: Request; env: Env }) {
     });
   } catch (err) {
     // Avoid exposing stack traces; log internally when debug is enabled
-    debugLog(context.env as any, "movie-lookup error", err);
+    debugLog(context.env, "movie-lookup error", err);
     return new Response(JSON.stringify({ error: "Internal server error" }), {
       status: 500,
       headers: { "Content-Type": "application/json", ...cors },

--- a/functions/test/movie-search.ts
+++ b/functions/test/movie-search.ts
@@ -1,5 +1,7 @@
 // AI Generated: GitHub Copilot - 2025-08-16
-export async function onRequest(context: any) {
+import type { Env as CacheEnv } from "../letterboxd/cache/index.js";
+
+export async function onRequest(context: { request: Request; env: CacheEnv }) {
   const { env } = context;
 
   try {

--- a/functions/test/movie-search.ts
+++ b/functions/test/movie-search.ts
@@ -1,4 +1,4 @@
-// AI Generated: GitHub Copilot - 2025-08-16
+// AI Generated: GitHub Copilot (claude-sonnet-3.5) - 2026-06-03
 import type { Env as CacheEnv } from "../letterboxd/cache/index.js";
 
 export async function onRequest(context: { request: Request; env: CacheEnv }) {

--- a/functions/test/tmdb-check.ts
+++ b/functions/test/tmdb-check.ts
@@ -1,5 +1,7 @@
 // AI Generated: GitHub Copilot - 2025-08-16
-export async function onRequest(context: any) {
+import type { Env as CacheEnv } from "../letterboxd/cache/index.js";
+
+export async function onRequest(context: { request: Request; env: CacheEnv }) {
   const { env } = context;
 
   try {

--- a/functions/test/tmdb-check.ts
+++ b/functions/test/tmdb-check.ts
@@ -1,4 +1,4 @@
-// AI Generated: GitHub Copilot - 2025-08-16
+// AI Generated: GitHub Copilot (claude-sonnet-3.5) - 2026-06-03
 import type { Env as CacheEnv } from "../letterboxd/cache/index.js";
 
 export async function onRequest(context: { request: Request; env: CacheEnv }) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "@typescript-eslint/eslint-plugin": "^8.59.4",
-        "@typescript-eslint/parser": "^8.59.4",
+        "@typescript-eslint/parser": "^8.60.0",
         "@vitejs/plugin-react": "^6.0.2",
         "eslint": "^10.0.0",
         "eslint-plugin-react": "^7.37.5",
@@ -2785,16 +2785,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
-      "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
+      "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.4",
-        "@typescript-eslint/types": "8.59.4",
-        "@typescript-eslint/typescript-estree": "8.59.4",
-        "@typescript-eslint/visitor-keys": "8.59.4",
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2810,14 +2810,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
-      "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
+      "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.4",
-        "@typescript-eslint/types": "^8.59.4",
+        "@typescript-eslint/tsconfig-utils": "^8.60.0",
+        "@typescript-eslint/types": "^8.60.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2832,14 +2832,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
-      "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
+      "integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.4",
-        "@typescript-eslint/visitor-keys": "8.59.4"
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2850,9 +2850,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
-      "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
+      "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2867,9 +2867,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
-      "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
+      "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2881,16 +2881,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
-      "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
+      "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.4",
-        "@typescript-eslint/tsconfig-utils": "8.59.4",
-        "@typescript-eslint/types": "8.59.4",
-        "@typescript-eslint/visitor-keys": "8.59.4",
+        "@typescript-eslint/project-service": "8.60.0",
+        "@typescript-eslint/tsconfig-utils": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2909,13 +2909,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
-      "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
+      "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/types": "8.60.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "typescript": "^6.0.3",
         "vite": "^8.0.14",
         "vitest": "^4.0.16",
-        "wrangler": "^4.80.0"
+        "wrangler": "^4.95.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -382,24 +382,24 @@
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
-      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
-      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+        "workerd": ">1.20260305.0 <2.0.0-0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260401.1.tgz",
-      "integrity": "sha512-ZSmceM70jH6k+/62VkEcmMNzrpr4kSctkX5Lsgqv38KktfhPY/hsh75y1lRoPWS3H3kgMa4p2pUSlidZR1u2hw==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260526.1.tgz",
+      "integrity": "sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==",
       "cpu": [
         "x64"
       ],
@@ -425,9 +425,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260401.1.tgz",
-      "integrity": "sha512-7UKWF+IUZ3NXMVPsDg8Cjg0r58b+uYlfvs5Yt8bvtU+geCtW4P2MxRHmRSEo8SryckXOJjb/b8tcncgCykFu8g==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260526.1.tgz",
+      "integrity": "sha512-rcyu0iANYfaiezKh3Mcao1O4IIgVfQldxduiL5TZT1sP0NIeRY4YReSTrzPxNnXxSYaIqaqRHMcHbUM/ic4knA==",
       "cpu": [
         "arm64"
       ],
@@ -442,9 +442,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260401.1.tgz",
-      "integrity": "sha512-MDWUH/0bvL/l9aauN8zEddyYOXId1OueqrUCXXENNJ95R/lSmF6OgGVuXaYhoIhxQkNiEJ/0NOlnVYj9mJq4dw==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260526.1.tgz",
+      "integrity": "sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==",
       "cpu": [
         "x64"
       ],
@@ -459,9 +459,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260401.1.tgz",
-      "integrity": "sha512-UgkzpMzVWM/bwbo3vjCTg2aoKfGcUhiEoQoDdo6RGWvbHRJyLVZ4VQCG9ZcISiztkiS2ICCoYOtPy6M/lV6Gcw==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260526.1.tgz",
+      "integrity": "sha512-X/YBQXeXFeCN7QTStoWrATEBc9WKl7PIqkw/dQkjyJ72gh3rkLe0+Xkzp3wO7gtxTDQMa7NPGy1W4+sdMf8q1g==",
       "cpu": [
         "arm64"
       ],
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260401.1.tgz",
-      "integrity": "sha512-HBLzcQF5iF4Qv20tQ++pG7xs3OsCnaIbc+GAi6fmhUKZhvmzvml/jwrQzLJ+MPm0cQo41K5OO/U3T4S8tvJetQ==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260526.1.tgz",
+      "integrity": "sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==",
       "cpu": [
         "x64"
       ],
@@ -1906,19 +1906,6 @@
         "@poppinss/colors": "^4.1.5",
         "@sindresorhus/is": "^7.0.2",
         "supports-color": "^10.0.0"
-      }
-    },
-    "node_modules/@poppinss/dumper/node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/@poppinss/exception": {
@@ -6142,24 +6129,24 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260401.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260401.0.tgz",
-      "integrity": "sha512-lngHPzZFN9sxYG/mhzvnWiBMNVAN5MsO/7g32ttJ07rymtiK/ZBalODTKb8Od+BQdlU5DOR4CjVt9NydjnUyYg==",
+      "version": "4.20260526.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260526.0.tgz",
+      "integrity": "sha512-JYQ7jPZZWoaaj9jWHb8Ucp6Cu2SbDVqIsAJhumqdzzLkkfq0pYkDeino/sZfW1ixJWPjv/C44zjm9gVJC2izCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
-        "undici": "7.24.4",
-        "workerd": "1.20260401.1",
-        "ws": "8.18.0",
+        "undici": "7.24.8",
+        "workerd": "1.20260526.1",
+        "ws": "8.20.1",
         "youch": "4.1.0-beta.10"
       },
       "bin": {
         "miniflare": "bootstrap.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/minimatch": {
@@ -6892,6 +6879,66 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rosie-skills": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills/-/rosie-skills-0.6.4.tgz",
+      "integrity": "sha512-ojfhSiQRdZ2QyWbmKAHOSAUbaLYrTc5zIH7mS1jKoP8KCFSQddwVhMyFqldckTeybTfW3zNcsZzyOTzGTN1SBA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "rosie-skills": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "rosie-skills-darwin-arm64": "0.6.4",
+        "rosie-skills-freebsd-x64": "0.6.4",
+        "rosie-skills-linux-x64": "0.6.4"
+      }
+    },
+    "node_modules/rosie-skills-darwin-arm64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-darwin-arm64/-/rosie-skills-darwin-arm64-0.6.4.tgz",
+      "integrity": "sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rosie-skills-freebsd-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-freebsd-x64/-/rosie-skills-freebsd-x64-0.6.4.tgz",
+      "integrity": "sha512-SxCRduPBMtfjkQ+q56Yw9OLA3PyaqoALzt7kER7IDKuUVfM2O/1w8sa5xhTDiCvWkZJixnH5d5Ya6KT+/Mwcng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/rosie-skills-linux-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-linux-x64/-/rosie-skills-linux-x64-0.6.4.tgz",
+      "integrity": "sha512-D9Y9mfu7goB0s0X59uU3hcFeUTef3VbpCIDwFMzyvJrAq3XhRACWBDMHQsHlyWdHxTXPX/ILyW65RXyrJlgqng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -7414,6 +7461,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -7696,9 +7756,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8201,9 +8261,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260401.1.tgz",
-      "integrity": "sha512-mUYCd+ohaWJWF5nhDzxugWaAD/DM8Dw0ze3B7bu8JaA7S70+XQJXcvcvwE8C4qGcxSdCyqjsrFzqxKubECDwzg==",
+      "version": "1.20260526.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260526.1.tgz",
+      "integrity": "sha512-IHzymht98p10JH1zzwdCpbViAqw97HrwKl7+KfZeASFMsYSrIsAULWdPn0LRC5FTUzBpamLNyKCCKxbgXHgRHQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -8214,41 +8274,42 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260401.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260401.1",
-        "@cloudflare/workerd-linux-64": "1.20260401.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260401.1",
-        "@cloudflare/workerd-windows-64": "1.20260401.1"
+        "@cloudflare/workerd-darwin-64": "1.20260526.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260526.1",
+        "@cloudflare/workerd-linux-64": "1.20260526.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260526.1",
+        "@cloudflare/workerd-windows-64": "1.20260526.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.80.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.80.0.tgz",
-      "integrity": "sha512-2ZKF7uPeOZy65BGk3YfvqBCPo/xH1MrAlMmH9mVP+tCNBrTUMnwOHSj1HrZHgR8LttkAqhko0fGz+I4ax1rzyQ==",
+      "version": "4.95.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.95.0.tgz",
+      "integrity": "sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.16.0",
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260401.0",
+        "miniflare": "4.20260526.0",
         "path-to-regexp": "6.3.0",
+        "rosie-skills": "^0.6.3",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260401.1"
+        "workerd": "1.20260526.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=20.3.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260401.1"
+        "@cloudflare/workers-types": "^4.20260526.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -8306,9 +8367,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "prettier": "^3.8.3",
         "typescript": "^6.0.3",
         "vite": "^8.0.14",
-        "vitest": "^4.0.16",
+        "vitest": "^4.1.0",
         "wrangler": "^4.95.0"
       },
       "engines": {
@@ -2179,356 +2179,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -3132,17 +2782,17 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -3150,13 +2800,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.0",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3165,7 +2815,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -3177,9 +2827,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3190,13 +2840,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.0",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3204,13 +2854,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3219,9 +2870,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3229,13 +2880,14 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.0.3"
       },
       "funding": {
@@ -4146,9 +3798,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6819,51 +6471,6 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/rosie-skills": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/rosie-skills/-/rosie-skills-0.6.4.tgz",
@@ -7259,9 +6866,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7501,9 +7108,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7848,31 +7455,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
         "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -7888,12 +7495,13 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -7922,81 +7530,9 @@
         },
         "jsdom": {
           "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
         },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "husky": "^9.1.7",
         "jsdom": "^29.1.0",
-        "lint-staged": "^16.3.0",
+        "lint-staged": "^17.0.7",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3",
         "vite": "^8.0.14",
@@ -3311,6 +3311,19 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -3555,19 +3568,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -3700,37 +3700,20 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^7.1.0",
-        "string-width": "^8.0.0"
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
         "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/concat-map": {
@@ -4648,19 +4631,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4792,9 +4762,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5313,16 +5283,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -5953,46 +5913,45 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.3.0.tgz",
-      "integrity": "sha512-YVHHy/p6U4/No9Af+35JLh3umJ9dPQnGTvNCbfO/T5fC60us0jFnc+vw33cqveI+kqxIFJQakcMVTO2KM+653A==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.7.tgz",
+      "integrity": "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
-        "listr2": "^9.0.5",
-        "micromatch": "^4.0.8",
-        "nano-spawn": "^2.0.0",
+        "listr2": "^10.2.1",
+        "picomatch": "^4.0.4",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.0.2",
-        "yaml": "^2.8.2"
+        "tinyexec": "^1.2.4"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
       },
       "engines": {
-        "node": ">=20.17"
+        "node": ">=22.22.1"
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/listr2": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
-      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^5.0.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
         "log-update": "^6.1.0",
         "rfdc": "^1.4.1",
-        "wrap-ansi": "^9.0.0"
+        "wrap-ansi": "^10.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/locate-path": {
@@ -6029,6 +5988,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/loose-envify": {
@@ -6090,20 +6102,6 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
@@ -6171,19 +6169,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nano-spawn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
-      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -6512,13 +6497,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -7240,33 +7225,20 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/source-map-js": {
@@ -7318,9 +7290,9 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7433,13 +7405,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -7502,9 +7474,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7526,19 +7498,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tinyrainbow": {
@@ -7570,19 +7529,6 @@
       "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
@@ -7901,19 +7847,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitest": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
@@ -7990,19 +7923,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest/node_modules/vite": {
@@ -8318,52 +8238,21 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ws": {
@@ -8413,11 +8302,12 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boxdbud-io",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boxdbud-io",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "react": "^19.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "lint-staged": "^16.3.0",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3",
-        "vite": "^8.0.10",
+        "vite": "^8.0.14",
         "vitest": "^4.0.16",
         "wrangler": "^4.80.0"
       },
@@ -1877,9 +1877,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1929,9 +1929,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
       "cpu": [
         "arm64"
       ],
@@ -1946,9 +1946,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
       "cpu": [
         "arm64"
       ],
@@ -1963,9 +1963,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
       "cpu": [
         "x64"
       ],
@@ -1980,9 +1980,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
       "cpu": [
         "x64"
       ],
@@ -1997,9 +1997,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
       "cpu": [
         "arm"
       ],
@@ -2014,9 +2014,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
       "cpu": [
         "arm64"
       ],
@@ -2031,9 +2031,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
       "cpu": [
         "arm64"
       ],
@@ -2048,9 +2048,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
       "cpu": [
         "ppc64"
       ],
@@ -2065,9 +2065,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
       "cpu": [
         "s390x"
       ],
@@ -2082,9 +2082,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
       "cpu": [
         "x64"
       ],
@@ -2099,9 +2099,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
       "cpu": [
         "x64"
       ],
@@ -2116,9 +2116,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
       "cpu": [
         "arm64"
       ],
@@ -2133,9 +2133,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
       "cpu": [
         "wasm32"
       ],
@@ -2152,9 +2152,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
       "cpu": [
         "arm64"
       ],
@@ -2169,9 +2169,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
       "cpu": [
         "x64"
       ],
@@ -2669,9 +2669,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6199,9 +6199,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -6548,9 +6548,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -6568,7 +6568,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6814,14 +6814,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -6830,29 +6830,22 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
-    },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.2",
@@ -7771,16 +7764,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -7797,7 +7790,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://boxdbud.io",
   "engines": {
-    "node": "^20.19.0 || ^22.13.0 || >=24"
+    "node": ">=20.10.0"
   },
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "boxdbud-io",
   "private": true,
-  "version": "2.1.4",
+  "version": "2.1.5",
   "type": "module",
   "license": "AGPL-3.0-or-later",
   "author": "Wootehfook",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
-    "@typescript-eslint/parser": "^8.59.4",
+    "@typescript-eslint/parser": "^8.60.0",
     "@vitejs/plugin-react": "^6.0.2",
     "eslint": "^10.0.0",
     "eslint-plugin-react": "^7.37.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://boxdbud.io",
   "engines": {
-    "node": ">=20.10.0"
+    "node": ">=22.22.1"
   },
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "husky": "^9.1.7",
     "jsdom": "^29.1.0",
-    "lint-staged": "^16.3.0",
+    "lint-staged": "^17.0.7",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "vite": "^8.0.14",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lint-staged": "^16.3.0",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
-    "vite": "^8.0.10",
+    "vite": "^8.0.14",
     "vitest": "^4.0.16",
     "wrangler": "^4.80.0"
   }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "typescript": "^6.0.3",
     "vite": "^8.0.14",
     "vitest": "^4.0.16",
-    "wrangler": "^4.80.0"
+    "wrangler": "^4.95.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "vite": "^8.0.14",
-    "vitest": "^4.0.16",
+    "vitest": "^4.1.0",
     "wrangler": "^4.95.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## Version Bump: 2.1.4 → 2.1.5 and tooling hygiene

This PR bumps the version from `2.1.4` to `2.1.5`.
In addition to the version increment, this PR raises TypeScript target compile scope to ES2022, increases necessary node engine caps, upgrades dependencies and improves D1 DB and function array typing hygiene across the codebase.

### Changes
- Bump `package.json` / `CHANGELOG.md` version to 2.1.5
- Update TypeScript config to `ES2022`
- Update dev tooling deps (`wrangler`, `lint-staged`, `vite`, `vitest`, `@typescript-eslint/parser`, node engine bounds >=22.22.1)
- Tighten Cloudflare D1 db array typings in Pages Functions routines

---

**Note:** After this PR is merged, the "Create GitHub Release" workflow will automatically create the tag and release.

- **Tag:** `v2.1.5`
- **Target:** `main`