### PR TITLE
chore: sync main (v2.1.5) back into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.5] - 2026-06-10
+
+### Changed
+
+- Bumped frontend tooling (`vite`, `vitest`, `wrangler`, `lint-staged`)
+- Raised TypeScript compile targets to `ES2022`
+- Introduced stronger Cloudflare D1 types array query responses in letterboxd functions
+
 ## [2.1.4] - 2026-05-25
 
 ### Changed
@@ -161,7 +169,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned repository of generated artifacts
 - Removed accidental secrets from repository
 
-[Unreleased]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.4...HEAD
+[Unreleased]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.5...HEAD
+[2.1.5]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.4...v2.1.5
 [2.1.4]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/Wootehfook/BoxdBuddies/compare/v2.1.1...v2.1.2

--- a/functions/api/watchlist-comparison/index.ts
+++ b/functions/api/watchlist-comparison/index.ts
@@ -610,7 +610,9 @@ const enhanceCommonMovies = async (
 ) => {
   const { isDebug } = await import("../../_lib/common");
   const debugMatchingFlag = (env as EnvWithDebugMatching).DEBUG_MATCHING;
-  const enableMatchingDebug = Boolean(isDebug(env) || debugMatchingFlag);
+  const enableMatchingDebug = Boolean(
+    isDebug(env) || debugMatchingFlag === true || debugMatchingFlag === "true"
+  );
   const enhancedMovies = await enhanceWithTMDBData(
     commonMovies,
     env,

--- a/functions/letterboxd/watchlist-count/index.ts
+++ b/functions/letterboxd/watchlist-count/index.ts
@@ -5,22 +5,13 @@
  */
 
 import { debugLog } from "../../_lib/common";
+import type { D1DatabaseLike } from "../cache/index.js";
 import type { Env as CacheEnv } from "../cache/index.js";
 
 interface WatchlistCount {
   username: string;
   count: number;
   lastUpdated: number;
-}
-
-interface D1PreparedStatementLike {
-  bind(...values: unknown[]): D1PreparedStatementLike;
-  first<T = Record<string, unknown>>(): Promise<T | null>;
-  run(): Promise<{ meta: { changes: number } }>;
-}
-
-interface D1DatabaseLike {
-  prepare(query: string): D1PreparedStatementLike;
 }
 
 // Rate limiting - 1 second between requests to be respectful to Letterboxd

--- a/functions/test/movie-search.ts
+++ b/functions/test/movie-search.ts
@@ -1,4 +1,4 @@
-// AI Generated: GitHub Copilot - 2025-08-16
+// AI Generated: GitHub Copilot (claude-sonnet-3.5) - 2026-06-03
 import type { Env as CacheEnv } from "../letterboxd/cache/index.js";
 
 export async function onRequest(context: { request: Request; env: CacheEnv }) {

--- a/functions/test/tmdb-check.ts
+++ b/functions/test/tmdb-check.ts
@@ -1,4 +1,4 @@
-// AI Generated: GitHub Copilot - 2025-08-16
+// AI Generated: GitHub Copilot (claude-sonnet-3.5) - 2026-06-03
 import type { Env as CacheEnv } from "../letterboxd/cache/index.js";
 
 export async function onRequest(context: { request: Request; env: CacheEnv }) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boxdbud-io",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boxdbud-io",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "react": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "boxdbud-io",
   "private": true,
-  "version": "2.1.4",
+  "version": "2.1.5",
   "type": "module",
   "license": "AGPL-3.0-or-later",
   "author": "Wootehfook",
@@ -12,7 +12,7 @@
   },
   "homepage": "https://boxdbud.io",
   "engines": {
-    "node": "^20.19.0 || ^22.13.0 || >=24"
+    "node": ">=22.22.1"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Supersedes #287. `develop` was behind `main`'s v2.1.5 release: PR #286 squash-merged `release/v2.1.5` into `main`, which broke shared commit ancestry with `develop` (develop has the same 12 changes as individual commits, main has them as one squashed commit). #287 tried to merge `main` into `develop` to fix this but couldn't be resolved cleanly — its head branch was `main` itself, so pushing a conflict-resolution commit to it would have meant pushing directly to `main`.

This PR does the same sync properly: a linear commit (not a merge commit — the repo's branch rulesets disallow those) built from a dedicated `chore/*` branch off `develop`, cherry-picking main's tip commit (`75dbcec`) and resolving the resulting conflicts.

### Conflicts resolved (in favor of `main`)

`main` diverged from `develop` only in 4 files, where two post-release-cut "address copilot review comments" commits landed on the release branch but were never back-ported to `develop`:

- `functions/api/watchlist-comparison/index.ts` — more permissive `DEBUG_MATCHING` flag check
- `functions/letterboxd/watchlist-count/index.ts` — reuse shared `D1DatabaseLike`/`D1PreparedStatementLike` typings from `cache/index.ts` instead of local duplicate interfaces
- `functions/test/movie-search.ts`, `functions/test/tmdb-check.ts` — AI attribution header date update

All other files (`CHANGELOG.md`, `package.json`, `package-lock.json`) auto-merged with no conflicts (version bump to 2.1.5, changelog entry).

Verified locally: the resulting file tree is byte-identical whether produced via `git merge origin/main` or via this cherry-pick approach — confirming this is a pure history-shape choice, not a different resolution.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:run` — 35 files / 117 tests passing
- [x] `npm run build` — succeeds
- [ ] CI checks on this PR (backend-quality-checks, security-audit, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
