### PR TITLE
chore: automate main-to-develop sync after releases

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,9 +108,17 @@ This project uses a **Gitflow-inspired model**. The `develop` branch is the inte
 
 ```
 feature/*, fix/*, chore/*, etc.  ──PR──▶  develop  ──PR──▶  main
-                                              │
+                                              │                │
                                     release/* / hotfix/*  ──PR──▶  main
+                                              ▲                │
+                                              └── auto-sync ───┘
 ```
+
+After a `release/*`/`hotfix/*` PR merges into `main`, the `sync-main-to-develop.yml`
+workflow automatically opens a `chore/sync-*` PR to bring that same content back
+into `develop`. This runs immediately (not "whenever someone remembers"), which is
+what keeps it conflict-free — see #287, which sat unmerged for three weeks and had
+to be resolved by hand as #296.
 
 ### Rules for AI contributors
 
@@ -119,6 +127,8 @@ feature/*, fix/*, chore/*, etc.  ──PR──▶  develop  ──PR──▶  
 3. Use Conventional Commit branch prefixes: `feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, `perf/`, `test/`.
 4. Never push directly to `main` or `develop`.
 5. When the Copilot Coding Agent creates a PR, verify the base is `develop`. If it's `main`, the auto-retarget workflow will redirect it.
+6. Every branch ruleset in this repo (`main`, `develop`, `release/*`/`hotfix/*`, and feature branches) enforces linear history — merge commits are rejected. Never merge one branch into another with `git merge`; use a rebase or cherry-pick to produce a single linear commit instead.
+7. Never make a PR's head branch literally `main` or `develop` (e.g. for a "sync" PR). Resolving conflicts on such a PR would require pushing new commits directly onto that branch. Always use a dedicated branch (e.g. `chore/sync-*`) as the head, targeting the branch you want to update as the base.
 
 ## 10) Security & secrets (must follow)
 

--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -105,6 +105,15 @@ jobs:
             exit 0
           fi
 
+          # Guard 3b (NEW): Skip main->develop sync PRs — they carry main's
+          # CHANGELOG.md content over verbatim via sync-main-to-develop.yml;
+          # adding a synthetic entry here would duplicate/pollute it.
+          if [[ "$PR_BRANCH" =~ ^chore/sync-.*-to-develop$ ]]; then
+            echo "Skipping main->develop sync PR (branch: $PR_BRANCH); CHANGELOG already carried over from main."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Guard 4: Skip changelog update PRs (body marker) to avoid recursion
           if [[ "$PR_BODY" == *"<!-- changelog-update -->"* ]]; then
             echo "Skipping changelog update PR (body marker) to avoid recursion."

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,35 @@
+name: Dependabot Auto-Merge
+
+# Enables auto-merge on Dependabot PRs for patch/minor updates once CI is
+# green and the required human review is given. This does NOT skip review
+# (branch rulesets still require an approval) — it just removes the manual
+# "click merge" step so patch/minor bumps stop piling up waiting on nothing
+# but a click.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch/minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+# AI Generated: Claude Sonnet 5 - 2026-07-05

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,3 +1,4 @@
+# AI Generated: GitHub Copilot (Claude Sonnet 5) - 2026-07-05
 name: Dependabot Auto-Merge
 
 # Enables auto-merge on Dependabot PRs for patch/minor updates once CI is
@@ -31,5 +32,3 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge --auto --squash "$PR_URL"
-
-# AI Generated: Claude Sonnet 5 - 2026-07-05

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -1,0 +1,204 @@
+name: Sync Main to Develop
+
+# After a release/hotfix lands on main, immediately propose the same
+# content back into develop as a linear commit. Running this the moment
+# main advances (rather than relying on someone to remember, days or
+# weeks later) is what keeps this operation conflict-free: see PR #287,
+# which sat open for three weeks and accumulated conflicts that #296 had
+# to resolve by hand.
+#
+# A merge commit is not used here: every branch ruleset in this repo
+# enforces required_linear_history, so a two-parent commit would be
+# rejected (or only pushed via an admin bypass). Instead this cherry-picks
+# main's merge commit onto a fresh branch off develop, producing a single
+# linear commit with identical resulting content.
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    if: |
+      github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+       startsWith(github.event.pull_request.head.ref, 'hotfix/'))
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_PR_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+    steps:
+      - name: Validate release PR token
+        run: |
+          if [ -z "$RELEASE_PR_TOKEN" ]; then
+            echo "::error::RELEASE_PR_TOKEN secret is required to create PRs that trigger required checks."
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ env.RELEASE_PR_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Set sync branch name
+        id: branch
+        run: |
+          SUFFIX="${HEAD_REF#release/}"
+          SUFFIX="${SUFFIX#hotfix/}"
+          SUFFIX=$(echo "$SUFFIX" | tr -c 'a-zA-Z0-9._-' '-')
+          BRANCH="chore/sync-${SUFFIX}-to-develop"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Create sync branch from develop
+        run: |
+          git fetch origin develop
+          git checkout -b "${{ steps.branch.outputs.branch }}" origin/develop
+
+      - name: Attempt cherry-pick of merge commit
+        id: cherry_pick
+        run: |
+          set +e
+          git cherry-pick --no-commit "$MERGE_SHA"
+          STATUS=$?
+          set -e
+          if [ $STATUS -ne 0 ]; then
+            CONFLICTS=$(git diff --name-only --diff-filter=U || true)
+            {
+              echo "conflicts<<SYNC_EOF"
+              echo "$CONFLICTS"
+              echo "SYNC_EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "clean=false" >> "$GITHUB_OUTPUT"
+            git cherry-pick --abort
+          else
+            echo "clean=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit sync
+        if: steps.cherry_pick.outputs.clean == 'true'
+        run: |
+          if git diff --cached --quiet; then
+            echo "No changes to sync — develop already contains this content."
+            echo "SYNC_SKIP=true" >> "$GITHUB_ENV"
+          else
+            git commit -m "chore: sync main ($HEAD_REF) back into develop
+
+          Brings develop up to date with main after merging #$PR_NUMBER ($HEAD_REF). Applied as a linear commit (cherry-pick, not a merge commit) since repo branch rulesets require linear history."
+          fi
+
+      - name: Install dependencies and verify
+        if: steps.cherry_pick.outputs.clean == 'true' && env.SYNC_SKIP != 'true'
+        run: |
+          npm ci --ignore-scripts
+          npm run type-check
+          npm run lint
+          npm run test:run
+          npm run build
+
+      - name: Push sync branch
+        if: steps.cherry_pick.outputs.clean == 'true' && env.SYNC_SKIP != 'true'
+        run: git push origin "${{ steps.branch.outputs.branch }}"
+
+      - name: Open sync PR
+        if: steps.cherry_pick.outputs.clean == 'true' && env.SYNC_SKIP != 'true'
+        id: create_pr
+        env:
+          GH_TOKEN: ${{ env.RELEASE_PR_TOKEN }}
+        run: |
+          PR_BODY_FILE=/tmp/sync_pr_body.md
+          {
+            echo "Automatically syncs \`main\` back into \`develop\` after merging #$PR_NUMBER (\`$HEAD_REF\`)."
+            echo ""
+            echo "This keeps \`develop\`'s history from drifting away from \`main\`, which otherwise causes conflicts the next time a sync is needed (see #287 / #296)."
+            echo ""
+            echo "- **Source:** \`main\` @ $MERGE_SHA"
+            echo "- **Method:** linear cherry-pick (merge commits are disallowed by branch rules)"
+            echo ""
+            echo "If CI passes and this gets approved, it will merge automatically."
+          } > "$PR_BODY_FILE"
+
+          PR_URL=$(gh pr create \
+            --title "chore: sync main ($HEAD_REF) back into develop" \
+            --body-file "$PR_BODY_FILE" \
+            --base develop \
+            --head "${{ steps.branch.outputs.branch }}")
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          gh pr edit "$PR_URL" --add-label "automated" 2>/dev/null || true
+
+      - name: Enable auto-merge
+        if: steps.cherry_pick.outputs.clean == 'true' && env.SYNC_SKIP != 'true'
+        env:
+          GH_TOKEN: ${{ env.RELEASE_PR_TOKEN }}
+        run: gh pr merge --auto --squash "${{ steps.create_pr.outputs.pr_url }}"
+
+      - name: Report conflict — manual resolution needed
+        if: steps.cherry_pick.outputs.clean == 'false'
+        env:
+          GH_TOKEN: ${{ env.RELEASE_PR_TOKEN }}
+          CONFLICTS: ${{ steps.cherry_pick.outputs.conflicts }}
+        run: |
+          COMMENT_FILE=/tmp/conflict_comment.md
+          {
+            echo "## ⚠️ Automatic sync to develop failed"
+            echo ""
+            echo "Merging \`main\` (from this PR, \`$HEAD_REF\`) back into \`develop\` hit conflicts that need manual resolution."
+            echo ""
+            echo "**Conflicting files:**"
+            echo '```'
+            echo "$CONFLICTS"
+            echo '```'
+            echo ""
+            echo "**To resolve:**"
+            echo '```bash'
+            echo "git fetch origin"
+            echo "git checkout -b chore/sync-manual-to-develop origin/develop"
+            echo "git cherry-pick --no-commit $MERGE_SHA"
+            echo "# resolve conflicts, then:"
+            echo "git add -A && git commit"
+            echo "git push -u origin chore/sync-manual-to-develop"
+            echo "gh pr create --base develop --head chore/sync-manual-to-develop"
+            echo '```'
+          } > "$COMMENT_FILE"
+          gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
+          echo "::error::Automatic sync to develop failed due to conflicts — see comment on PR #$PR_NUMBER for manual resolution steps."
+          exit 1
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Sync to develop"
+            echo ""
+            if [ "${{ steps.cherry_pick.outputs.clean }}" == "true" ]; then
+              if [ "$SYNC_SKIP" == "true" ]; then
+                echo "✅ develop already contained this content — nothing to sync."
+              else
+                echo "✅ Opened ${{ steps.create_pr.outputs.pr_url }} with auto-merge enabled."
+              fi
+            else
+              echo "❌ Conflicts detected — manual resolution required (see comment on #$PR_NUMBER)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+# AI Generated: Claude Sonnet 5 - 2026-07-05

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -1,3 +1,4 @@
+# AI Generated: GitHub Copilot (Claude Sonnet 5) - 2026-07-05
 name: Sync Main to Develop
 
 # After a release/hotfix lands on main, immediately propose the same
@@ -27,6 +28,7 @@ jobs:
   sync:
     if: |
       github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (startsWith(github.event.pull_request.head.ref, 'release/') ||
        startsWith(github.event.pull_request.head.ref, 'hotfix/'))
     runs-on: ubuntu-latest
@@ -102,9 +104,9 @@ jobs:
             echo "No changes to sync — develop already contains this content."
             echo "SYNC_SKIP=true" >> "$GITHUB_ENV"
           else
-            git commit -m "chore: sync main ($HEAD_REF) back into develop
-
-          Brings develop up to date with main after merging #$PR_NUMBER ($HEAD_REF). Applied as a linear commit (cherry-pick, not a merge commit) since repo branch rulesets require linear history."
+            git commit \
+              -m "chore: sync main ($HEAD_REF) back into develop" \
+              -m "Brings develop up to date with main after merging #$PR_NUMBER ($HEAD_REF). Applied as a linear commit (cherry-pick, not a merge commit) since repo branch rulesets require linear history."
           fi
 
       - name: Install dependencies and verify
@@ -200,5 +202,3 @@ jobs:
               echo "❌ Conflicts detected — manual resolution required (see comment on #$PR_NUMBER)."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-
-# AI Generated: Claude Sonnet 5 - 2026-07-05


### PR DESCRIPTION
## Summary

Implements Plan A from the PR #287/#296 postmortem: automate the release → develop sync so develop can't drift the way it did (three weeks unmerged, conflicts by the time anyone noticed).

- **`sync-main-to-develop.yml`** — triggers when a `release/*`/`hotfix/*` PR merges into `main`. Cherry-picks main's merge commit onto a fresh `chore/sync-*` branch off `develop` (a linear commit, not a merge commit — every branch ruleset here enforces `required_linear_history`), runs the full verification suite, opens a PR into `develop`, and enables auto-merge. If the cherry-pick conflicts, it comments on the release PR with exact manual-resolution steps instead of pushing broken state.
- **`dependabot-auto-merge.yml`** — enables auto-merge on patch/minor Dependabot PRs once approved and green. Doesn't skip the required review, just removes the manual merge click. (7 Dependabot PRs are currently sitting blocked on nothing but that click.)
- **`changelog-update.yml`** — added a guard so the auto-changelog bot skips `chore/sync-*` PRs; their `CHANGELOG.md` already comes verbatim from `main`, so the bot would otherwise add a duplicate entry.
- **`copilot-instructions.md` §9b** — documents the new auto-sync step, plus two rules learned the hard way: branch rulesets require linear history (no `git merge`, use rebase/cherry-pick), and never make a sync PR's head branch `main`/`develop` itself (that's what made #287 unfixable in place).

### Course correction from the original plan

I originally proposed switching release PRs to a "merge commit" strategy so `main` and `develop` would share commit ancestry. That's not viable — I checked all four branch rulesets (`main`, `develop`, `release/*`/`hotfix/*`, feature branches) and every one enforces `required_linear_history`, so a merge commit gets rejected outright (confirmed by hand while resolving #296 — it only went through via an admin bypass). The mitigation here is timing instead: sync immediately after every release so the diff is always trivial, rather than letting it compound over weeks.

## Test plan

- [x] YAML validated for both new workflow files
- [x] `npm run type-check` / `npm run lint` — clean (no source changes, workflow/docs only)
- [ ] Live end-to-end test happens on the next real release merge to `main` — can't fully dry-run a `pull_request: closed` trigger locally
- [ ] CI checks on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
