### PR TITLE
chore: group react/react-dom/@types updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: develop
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
     commit-message:
       prefix: "chore"
       prefix-development: "chore"


### PR DESCRIPTION
## Summary
- Adds a Dependabot `groups.react` entry (react, react-dom, @types/react, @types/react-dom) so these always bump together.

## Why
PR #301 (react + @types/react) and PR #302 (react-dom) landed as separate Dependabot PRs today, each pinning react/react-dom to mismatched versions. React throws `Incompatible React versions` at runtime when they diverge, which failed Test Suite and Backend Quality Checks on both PRs (7 test files failing each). Grouping the packages means Dependabot opens a single PR with matching versions instead.

## Recommendation for #301 / #302
Close both as superseded once this merges and a fresh grouped PR appears — merging either individually will reintroduce the mismatch.

## Test plan
- [ ] Confirm next Dependabot npm run opens a single grouped PR when react/react-dom update together
- [ ] Standard CI (build/tests) on this PR itself — no runtime code touched, config-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)