### PR TITLE
fix(shell): resolve 35 SonarCloud issues in shell scripts

### DIFF
--- a/.codacy/cli.sh
+++ b/.codacy/cli.sh
@@ -20,12 +20,15 @@ case "$arch" in
 "aarch64"|"arm64")
   arch="arm64"
   ;;
+*)
+  # Keep the architecture reported by uname for unlisted platforms
+  ;;
 esac
 
-if [ -z "$CODACY_CLI_V2_TMP_FOLDER" ]; then
-    if [ "$(uname)" = "Linux" ]; then
+if [[ -z "$CODACY_CLI_V2_TMP_FOLDER" ]]; then
+    if [[ "$(uname)" == "Linux" ]]; then
         CODACY_CLI_V2_TMP_FOLDER="$HOME/.cache/codacy/codacy-cli-v2"
-    elif [ "$(uname)" = "Darwin" ]; then
+    elif [[ "$(uname)" == "Darwin" ]]; then
         CODACY_CLI_V2_TMP_FOLDER="$HOME/Library/Caches/Codacy/codacy-cli-v2"
     else
         CODACY_CLI_V2_TMP_FOLDER=".codacy-cli-v2"
@@ -36,9 +39,9 @@ version_file="$CODACY_CLI_V2_TMP_FOLDER/version.yaml"
 
 
 get_version_from_yaml() {
-    if [ -f "$version_file" ]; then
+    if [[ -f "$version_file" ]]; then
         local version=$(grep -o 'version: *"[^"]*"' "$version_file" | cut -d'"' -f2)
-        if [ -n "$version" ]; then
+        if [[ -n "$version" ]]; then
             echo "$version"
             return 0
         fi
@@ -48,7 +51,7 @@ get_version_from_yaml() {
 
 get_latest_version() {
     local response
-    if [ -n "$GH_TOKEN" ]; then
+    if [[ -n "$GH_TOKEN" ]]; then
         response=$(curl -Lq --header "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/codacy/codacy-cli-v2/releases/latest" 2>/dev/null)
     else
         response=$(curl -Lq "https://api.github.com/repos/codacy/codacy-cli-v2/releases/latest" 2>/dev/null)
@@ -94,7 +97,7 @@ download_cli() {
     local bin_path="$2"
     local version="$3"
 
-    if [ ! -f "$bin_path" ]; then
+    if [[ ! -f "$bin_path" ]]; then
         echo "📥 Downloading CLI version $version..."
 
         remote_file="codacy-cli-v2_${version}_${suffix}_${arch}.tar.gz"
@@ -106,13 +109,13 @@ download_cli() {
 }
 
 # Warn if CODACY_CLI_V2_VERSION is set and update is requested
-if [ -n "$CODACY_CLI_V2_VERSION" ] && [ "$1" = "update" ]; then
+if [[ -n "$CODACY_CLI_V2_VERSION" && "$1" == "update" ]]; then
     echo "⚠️  Warning: Performing update with forced version $CODACY_CLI_V2_VERSION"
     echo "    Unset CODACY_CLI_V2_VERSION to use the latest version"
 fi
 
 # Ensure version.yaml exists and is up to date
-if [ ! -f "$version_file" ] || [ "$1" = "update" ]; then
+if [[ ! -f "$version_file" || "$1" == "update" ]]; then
     echo "ℹ️  Fetching latest version..."
     version=$(get_latest_version)
     mkdir -p "$CODACY_CLI_V2_TMP_FOLDER"
@@ -120,7 +123,7 @@ if [ ! -f "$version_file" ] || [ "$1" = "update" ]; then
 fi
 
 # Set the version to use
-if [ -n "$CODACY_CLI_V2_VERSION" ]; then
+if [[ -n "$CODACY_CLI_V2_VERSION" ]]; then
     version="$CODACY_CLI_V2_VERSION"
 else
     version=$(get_version_from_yaml)
@@ -138,11 +141,11 @@ download_cli "$bin_folder" "$bin_path" "$version"
 chmod +x "$bin_path"
 
 run_command="$bin_path"
-if [ -z "$run_command" ]; then
+if [[ -z "$run_command" ]]; then
     fatal "Codacy cli v2 binary could not be found."
 fi
 
-if [ "$#" -eq 1 ] && [ "$1" = "download" ]; then
+if [[ "$#" -eq 1 && "$1" == "download" ]]; then
     echo "Codacy cli v2 download succeeded"
 else
     eval "$run_command $*"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -20,8 +20,8 @@ NC='\033[0m' # No Color
 
 # Step 1: Install npm dependencies (if needed)
 echo "${BLUE}📦 Checking npm dependencies...${NC}"
-if [ ! -d "node_modules" ] || [ -z "$(ls -A node_modules 2>/dev/null)" ]; then
-  if [ -f "package-lock.json" ]; then
+if [[ ! -d "node_modules" || -z "$(ls -A node_modules 2>/dev/null)" ]]; then
+  if [[ -f "package-lock.json" ]]; then
     echo "${BLUE}Installing npm dependencies with npm ci (lockfile detected)...${NC}"
     npm ci --prefer-offline --no-audit 2>&1 || {
       echo "${YELLOW}⚠️  npm ci encountered permission or filesystem issues.${NC}"
@@ -52,7 +52,7 @@ fi
 echo ""
 
 # Step 3: Create .env.local if it doesn't exist
-if [ ! -f .env.local ]; then
+if [[ ! -f .env.local ]]; then
   echo "${BLUE}🔐 Creating .env.local template...${NC}"
   cat > .env.local << 'EOF'
 # Local development environment variables

--- a/.github/scripts/retry-failed-checks.sh
+++ b/.github/scripts/retry-failed-checks.sh
@@ -9,7 +9,7 @@ echo "🔄 CI Check Retry Automation Starting..."
 
 PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null || echo "")
 
-if [ -z "$PR_NUMBER" ]; then
+if [[ -z "$PR_NUMBER" ]]; then
     echo "❌ No active PR found in current context"
     exit 1
 fi
@@ -28,7 +28,7 @@ retry_failed_workflows() {
     # Get recent workflow runs that failed
     FAILED_RUNS=$(gh run list --branch temp-merge-branch --status failure --limit 5 --json databaseId,name,conclusion | jq -r '.[] | select(.conclusion == "failure") | .databaseId')
     
-    if [ -n "$FAILED_RUNS" ]; then
+    if [[ -n "$FAILED_RUNS" ]]; then
         echo "🚨 Found failed workflow runs, attempting to rerun..."
         for run_id in $FAILED_RUNS; do
             echo "🔄 Retrying workflow run: $run_id"
@@ -47,12 +47,12 @@ wait_for_checks() {
     local wait_time=0
     local check_interval=30
     
-    while [ $wait_time -lt $max_wait ]; do
+    while [[ $wait_time -lt $max_wait ]]; do
         local failing_checks=$(get_failing_checks)
         local in_progress=$(gh pr checks "$PR_NUMBER" --json status | jq -r '.[] | select(.status == "in_progress") | .name' | wc -l)
         
-        if [ "$in_progress" -eq 0 ]; then
-            if [ -z "$failing_checks" ]; then
+        if [[ "$in_progress" -eq 0 ]]; then
+            if [[ -z "$failing_checks" ]]; then
                 echo "✅ All checks passed!"
                 return 0
             else

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -29,8 +29,8 @@ HOOKS_DIR="$REPO_ROOT/.husky"
 echo "Setting up Git hooks for Boxdbud.io..."
 
 # Ensure .husky directory exists
-if [ ! -d "$HOOKS_DIR" ]; then
-  echo "Error: .husky directory not found. Run 'npm install' first."
+if [[ ! -d "$HOOKS_DIR" ]]; then
+  echo "Error: .husky directory not found. Run 'npm install' first." >&2
   exit 1
 fi
 
@@ -38,7 +38,7 @@ fi
 PRE_PUSH_HOOK="$HOOKS_DIR/pre-push"
 
 # Backup existing hook if it exists and is different
-if [ -f "$PRE_PUSH_HOOK" ]; then
+if [[ -f "$PRE_PUSH_HOOK" ]]; then
   echo "⚠️  Pre-push hook already exists. Creating backup..."
   cp "$PRE_PUSH_HOOK" "$PRE_PUSH_HOOK.backup.$(date +%Y%m%d_%H%M%S)"
   echo "✅ Backup created: $PRE_PUSH_HOOK.backup.$(date +%Y%m%d_%H%M%S)"

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -40,8 +40,11 @@ PRE_PUSH_HOOK="$HOOKS_DIR/pre-push"
 # Backup existing hook if it exists and is different
 if [[ -f "$PRE_PUSH_HOOK" ]]; then
   echo "⚠️  Pre-push hook already exists. Creating backup..."
-  cp "$PRE_PUSH_HOOK" "$PRE_PUSH_HOOK.backup.$(date +%Y%m%d_%H%M%S)"
-  echo "✅ Backup created: $PRE_PUSH_HOOK.backup.$(date +%Y%m%d_%H%M%S)"
+  # Compute the backup path once so the echoed name matches the file created
+  # (a second `date` call could produce a different timestamp).
+  backup_path="$PRE_PUSH_HOOK.backup.$(date +%Y%m%d_%H%M%S)"
+  cp "$PRE_PUSH_HOOK" "$backup_path"
+  echo "✅ Backup created: $backup_path"
 fi
 
 cat > "$PRE_PUSH_HOOK" << 'EOF'

--- a/scripts/setup-gpg.sh
+++ b/scripts/setup-gpg.sh
@@ -3,7 +3,7 @@
 # Usage: source this file to set up GPG environment
 
 # Check if GPG_PASSPHRASE is set
-if [ -z "$GPG_PASSPHRASE" ]; then
+if [[ -z "$GPG_PASSPHRASE" ]]; then
     echo "⚠️  GPG_PASSPHRASE environment variable not set"
     echo "To set it securely:"
     echo "export GPG_PASSPHRASE='your-passphrase-here'"
@@ -18,9 +18,7 @@ export GNUPGHOME=${GNUPGHOME:-~/.gnupg}
 
 # Test GPG signing
 echo "Testing GPG signing..."
-echo "test" | gpg --batch --passphrase "$GPG_PASSPHRASE" --pinentry-mode loopback --clearsign --local-user wootehfook@gmail.com > /dev/null 2>&1
-
-if [ $? -eq 0 ]; then
+if echo "test" | gpg --batch --passphrase "$GPG_PASSPHRASE" --pinentry-mode loopback --clearsign --local-user wootehfook@gmail.com > /dev/null 2>&1; then
     echo "✅ GPG signing configured successfully"
     echo "🔐 Passphrase cached for this session"
 else

--- a/scripts/setup-gpg.sh
+++ b/scripts/setup-gpg.sh
@@ -2,6 +2,13 @@
 # GPG signing helper script for BoxdBuddies
 # Usage: source this file to set up GPG environment
 
+# This script is intended to be sourced, so stop with `return` (which leaves
+# the caller's shell alive) and fall back to `exit` when run directly. The
+# pattern must be inline at the top level — a helper function's `return`
+# would only return from the function, not halt the sourced script. `return`
+# outside a sourced/function context errors harmlessly to /dev/null, so the
+# `|| exit` branch handles direct execution.
+
 # Check if GPG_PASSPHRASE is set
 if [[ -z "$GPG_PASSPHRASE" ]]; then
     echo "⚠️  GPG_PASSPHRASE environment variable not set"
@@ -9,11 +16,12 @@ if [[ -z "$GPG_PASSPHRASE" ]]; then
     echo "export GPG_PASSPHRASE='your-passphrase-here'"
     echo ""
     echo "Or use GPG agent for automatic caching (recommended)"
-    exit 1
+    return 1 2>/dev/null || exit 1
 fi
 
 # Export GPG environment for automated signing
-export GPG_TTY=$(tty)
+GPG_TTY=$(tty)
+export GPG_TTY
 export GNUPGHOME=${GNUPGHOME:-~/.gnupg}
 
 # Test GPG signing
@@ -23,5 +31,5 @@ if echo "test" | gpg --batch --passphrase "$GPG_PASSPHRASE" --pinentry-mode loop
     echo "🔐 Passphrase cached for this session"
 else
     echo "❌ GPG signing failed - check your passphrase"
-    exit 1
+    return 1 2>/dev/null || exit 1
 fi

--- a/scripts/test-versioning-workflows.sh
+++ b/scripts/test-versioning-workflows.sh
@@ -25,7 +25,7 @@ in_unreleased && /^## \[/ { exit }
 in_unreleased { print }
 ' CHANGELOG.md > "$TEST_DIR/unreleased.md"
 
-if [ -s "$TEST_DIR/unreleased.md" ]; then
+if [[ -s "$TEST_DIR/unreleased.md" ]]; then
     echo "✅ Successfully extracted unreleased changes"
     LINES=$(wc -l < "$TEST_DIR/unreleased.md" | awk '{print $1}')
     echo "   Found $LINES lines of content"
@@ -56,7 +56,7 @@ DATE=$(date +%Y-%m-%d)
   awk '/^## \[[0-9]/ { printing=1 } printing { print }' CHANGELOG.md
 } > "$TEST_DIR/changelog_updated.md"
 
-if [ -s "$TEST_DIR/changelog_updated.md" ]; then
+if [[ -s "$TEST_DIR/changelog_updated.md" ]]; then
     echo "✅ Successfully created updated CHANGELOG"
     
     # Verify structure
@@ -67,7 +67,7 @@ if [ -s "$TEST_DIR/changelog_updated.md" ]; then
         
         # Check for duplicates
         DUPLICATE_COUNT=$(grep -c "## \[2.1.0\]" "$TEST_DIR/changelog_updated.md")
-        if [ "$DUPLICATE_COUNT" -eq 1 ]; then
+        if [[ "$DUPLICATE_COUNT" -eq 1 ]]; then
             echo "✅ No duplicate version entries found"
         else
             echo "❌ Found duplicate version entries"
@@ -105,7 +105,7 @@ for test_entry in "${test_pr_titles[@]}"; do
         CHANGE_TYPE="Fixed"
     fi
     
-    if [ "$CHANGE_TYPE" = "$expected_type" ]; then
+    if [[ "$CHANGE_TYPE" == "$expected_type" ]]; then
         echo "✅ '$pr_title' → $CHANGE_TYPE"
     else
         echo "❌ '$pr_title' → Expected: $expected_type, Got: $CHANGE_TYPE"
@@ -117,7 +117,7 @@ echo ""
 # Test 4: Validate package.json version reading
 echo "Test 4: Validate package.json version reading"
 CURRENT_VERSION=$(node -p "require('./package.json').version")
-if [ -n "$CURRENT_VERSION" ]; then
+if [[ -n "$CURRENT_VERSION" ]]; then
     echo "✅ Successfully read version: $CURRENT_VERSION"
 else
     echo "❌ Failed to read version from package.json"


### PR DESCRIPTION
## Summary

Resolves all 35 SonarCloud issues reported against the repository's shell scripts (project `Wootehfook_BoxdBuddies`).

- **S7688** (Major, ×33): use `[[ ]]` instead of `[ ]` for conditional tests across `.codacy/cli.sh`, `.devcontainer/post-create.sh`, `.github/scripts/retry-failed-checks.sh`, `scripts/setup-git-hooks.sh`, `scripts/setup-gpg.sh`, `scripts/test-versioning-workflows.sh`
- **S131** (Critical, ×1): add a default `*)` case to the arch-detection `case` in `.codacy/cli.sh`
- **S7677** (Major, ×1): redirect error message to stderr in `scripts/setup-git-hooks.sh`
- Drive-by: check gpg exit status directly (`if cmd; then`) instead of `$?` in `scripts/setup-gpg.sh`
- Drive-by: normalize CRLF → LF in `retry-failed-checks.sh` and `setup-gpg.sh` — these were committed with literal carriage returns, which breaks bash on Linux (this is why those two files show whole-file diffs)

The heredoc-embedded `#!/bin/sh` hook in `setup-git-hooks.sh` intentionally keeps POSIX `[ ]` since it is not bash.

## Testing

- `bash -n` passes on all six scripts

Part 1 of 4 SonarCloud cleanup PRs (shell / CSS / functions TS / src TS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)