### PR TITLE
fix(src): resolve ~53 SonarCloud issues in frontend and scripts

### DIFF
--- a/scripts/check-supported-version.cjs
+++ b/scripts/check-supported-version.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* eslint-env node */
-// AI Generated: GitHub Copilot - 2025-08-08
+// AI Generated: GitHub Copilot (Claude Opus 4.8) - 2026-07-18
 // Ensures SECURITY.md Supported Versions matches the current major version in package.json
 const fs = require('node:fs');
 const path = require('node:path');

--- a/scripts/check-supported-version.cjs
+++ b/scripts/check-supported-version.cjs
@@ -2,8 +2,8 @@
 /* eslint-env node */
 // AI Generated: GitHub Copilot - 2025-08-08
 // Ensures SECURITY.md Supported Versions matches the current major version in package.json
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 function fail(msg, code = 1) {
   console.error(msg);
@@ -39,9 +39,16 @@ if (!match) {
 const major = match[1];
 
 // Be tolerant of table spacing by normalizing pipe spacing: "| 1.0.x |" -> "|1.0.x|"
+// split/trim instead of /\s*\|\s*/g, which backtracks super-linearly (sonar S8786)
 const normalized = sec
   .split('\n')
-  .map((line) => line.replace(/\s*\|\s*/g, '|').trim())
+  .map((line) =>
+    line
+      .split('|')
+      .map((cell) => cell.trim())
+      .join('|')
+      .trim()
+  )
   .join('\n');
 
 if (!normalized.includes(`|${major}.0.x|`)) {

--- a/scripts/check-supported-version.cjs
+++ b/scripts/check-supported-version.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* eslint-env node */
-// AI Generated: GitHub Copilot (Claude Opus 4.8) - 2026-07-18
+// AI Generated: Claude Opus 4.8 - 2026-07-18
 // Ensures SECURITY.md Supported Versions matches the current major version in package.json
 const fs = require('node:fs');
 const path = require('node:path');

--- a/scripts/emergency-rollback.js
+++ b/scripts/emergency-rollback.js
@@ -13,8 +13,8 @@
  *   node scripts/emergency-rollback.js [--dry-run] [--reason="explanation"]
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // Configuration
 const CONFIG = {

--- a/scripts/sync-favicon.mjs
+++ b/scripts/sync-favicon.mjs
@@ -1,4 +1,4 @@
-// AI Generated: GitHub Copilot (Claude Opus 4.8) - 2026-07-18
+// AI Generated: Claude Opus 4.8 - 2026-07-18
 // Copies a 128x128 PNG variant of BBud.png as the app favicon.
 // Requires: @tauri-apps/cli installed (icons already generated) and sharp (optional).
 

--- a/scripts/sync-favicon.mjs
+++ b/scripts/sync-favicon.mjs
@@ -3,25 +3,23 @@
 // Requires: @tauri-apps/cli installed (icons already generated) and sharp (optional).
 
 /* eslint-env node */
-import fs from 'fs';
-import path from 'path';
+import fs from "node:fs";
+import path from "node:path";
 
 const projectRoot = process.cwd();
-const sourcePng = path.join(projectRoot, 'BBud.png');
-const targetFavicon = path.join(projectRoot, 'public', 'favicon.png');
+const sourcePng = path.join(projectRoot, "BBud.png");
+const targetFavicon = path.join(projectRoot, "public", "favicon.png");
 
 // Minimal: just copy if exists; Vite can use PNG favicons via link rel icon.
-(async () => {
-  try {
-    if (!fs.existsSync(sourcePng)) {
-      console.log('icons:favicon: source BBud.png not found, skipping');
-      process.exit(0);
-    }
-    fs.mkdirSync(path.dirname(targetFavicon), { recursive: true });
-    fs.copyFileSync(sourcePng, targetFavicon);
-    console.log('icons:favicon: favicon.png updated');
-  } catch (err) {
-    console.error('icons:favicon failed:', err);
-    process.exit(1);
+try {
+  if (!fs.existsSync(sourcePng)) {
+    console.log("icons:favicon: source BBud.png not found, skipping");
+    process.exit(0);
   }
-})();
+  fs.mkdirSync(path.dirname(targetFavicon), { recursive: true });
+  fs.copyFileSync(sourcePng, targetFavicon);
+  console.log("icons:favicon: favicon.png updated");
+} catch (err) {
+  console.error("icons:favicon failed:", err);
+  process.exit(1);
+}

--- a/scripts/sync-favicon.mjs
+++ b/scripts/sync-favicon.mjs
@@ -1,4 +1,4 @@
-// AI Generated: GitHub Copilot - 2025-08-12
+// AI Generated: GitHub Copilot (Claude Opus 4.8) - 2026-07-18
 // Copies a 128x128 PNG variant of BBud.png as the app favicon.
 // Requires: @tauri-apps/cli installed (icons already generated) and sharp (optional).
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -536,6 +536,7 @@ function App() {
       <footer className="attribution">
         <div className="attribution-center">
           <button
+            type="button"
             className="attribution-link"
             onClick={() => setShowAttribution(true)}
             aria-haspopup="dialog"
@@ -547,6 +548,7 @@ function App() {
         {showAttribution && (
           <>
             <button
+              type="button"
               className="modal-backdrop-button"
               aria-label="Close data sources and attribution dialog"
               onClick={() => setShowAttribution(false)}
@@ -628,6 +630,7 @@ function App() {
               </div>
               <div className="modal-actions">
                 <button
+                  type="button"
                   onClick={() => setShowAttribution(false)}
                   className="btn btn-primary"
                 >

--- a/src/__tests__/attribution-modal.test.tsx
+++ b/src/__tests__/attribution-modal.test.tsx
@@ -36,7 +36,7 @@ describe("Attribution modal", () => {
       const headings = screen.queryAllByRole("heading", {
         name: /data sources & attribution/i,
       });
-      expect(headings.length).toBe(0);
+      expect(headings).toHaveLength(0);
     });
   });
 });

--- a/src/__tests__/cacheService.test.ts
+++ b/src/__tests__/cacheService.test.ts
@@ -53,7 +53,7 @@ describe("WebCacheService - watchlistCounts", () => {
 
   it("returns an empty map when no counts exist", () => {
     const all = WebCacheService.getAllWatchlistCounts();
-    expect(Object.keys(all).length).toBe(0);
+    expect(Object.keys(all)).toHaveLength(0);
   });
 
   it("getAllWatchlistCounts returns inserted entries and skips corrupted ones", () => {

--- a/src/components/FriendAvatar.tsx
+++ b/src/components/FriendAvatar.tsx
@@ -23,7 +23,7 @@ import { useState } from "react";
 import { getUserColors, isValidLetterboxdUrl, API_ENDPOINTS } from "../utils";
 import type { FriendAvatarProps } from "../types";
 
-export function FriendAvatar({ friend }: FriendAvatarProps) {
+export function FriendAvatar({ friend }: Readonly<FriendAvatarProps>) {
   const [imageError, setImageError] = useState(false);
 
   const initials = friend.displayName

--- a/src/components/FriendSelectionPage.tsx
+++ b/src/components/FriendSelectionPage.tsx
@@ -23,6 +23,26 @@ import { FAMOUS_MOVIE_QUOTES } from "../utils";
 import { FriendAvatar } from "./FriendAvatar";
 import type { FriendSelectionPageProps } from "../types";
 
+// Watchlist count line, extracted to avoid nested ternaries in JSX
+function WatchlistCountLine({
+  count,
+  isLoading,
+}: Readonly<{ count: number | undefined; isLoading: boolean }>) {
+  if (count !== undefined) {
+    const films = `${count} Film${count === 1 ? "" : "s"}`;
+    const label = count === 0 ? "Watchlist: NA" : `Watchlist: ${films}`;
+    return <p className="watchlist-count">{label}</p>;
+  }
+  if (isLoading) {
+    return (
+      <p className="watchlist-count">
+        <span className="loading-dots">Loading watchlist...</span>
+      </p>
+    );
+  }
+  return null;
+}
+
 export function FriendSelectionPage({
   friends,
   selectedFriends,
@@ -34,7 +54,7 @@ export function FriendSelectionPage({
   enhancementProgress,
   currentQuoteIndex,
   error,
-}: FriendSelectionPageProps) {
+}: Readonly<FriendSelectionPageProps>) {
   const progressPercent = Math.round(
     (enhancementProgress.completed / enhancementProgress.total) * 100
   );
@@ -42,7 +62,11 @@ export function FriendSelectionPage({
   return (
     <section className="page friends-page">
       <div className="page-header">
-        <button onClick={onBackToSetup} className="btn btn-secondary btn-icon">
+        <button
+          type="button"
+          onClick={onBackToSetup}
+          className="btn btn-secondary btn-icon"
+        >
           <svg
             viewBox="0 0 24 24"
             fill="none"
@@ -69,35 +93,37 @@ export function FriendSelectionPage({
         ) : (
           <>
             <div className="friends-grid">
-              {friends.map((friend, index) => (
-                <div
-                  key={friend.username}
-                  className={`friend-card fade-in ${selectedFriends.some((f) => f.username === friend.username) ? "selected" : ""}`}
-                  style={{ animationDelay: `${index * 0.1}s` }}
-                  onClick={() => onToggleFriend(friend)}
-                >
-                  <div className="friend-avatar">
-                    <FriendAvatar friend={friend} />
-                  </div>
-                  <div className="friend-info">
-                    <h3>{friend.displayName || friend.username}</h3>
-                    <p>@{friend.username}</p>
-                    {friend.watchlistCount !== undefined ? (
-                      <p className="watchlist-count">
-                        {friend.watchlistCount === 0
-                          ? "Watchlist: NA"
-                          : `Watchlist: ${friend.watchlistCount} Film${friend.watchlistCount === 1 ? "" : "s"}`}
-                      </p>
-                    ) : isLoadingWatchlistCounts ? (
-                      <p className="watchlist-count">
-                        <span className="loading-dots">
-                          Loading watchlist...
-                        </span>
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-              ))}
+              {friends.map((friend, index) => {
+                const isSelected = selectedFriends.some(
+                  (f) => f.username === friend.username
+                );
+                return (
+                  <button
+                    key={friend.username}
+                    type="button"
+                    aria-pressed={isSelected}
+                    className={`friend-card fade-in ${isSelected ? "selected" : ""}`}
+                    style={{
+                      animationDelay: `${index * 0.1}s`,
+                      font: "inherit",
+                      color: "inherit",
+                    }}
+                    onClick={() => onToggleFriend(friend)}
+                  >
+                    <div className="friend-avatar">
+                      <FriendAvatar friend={friend} />
+                    </div>
+                    <div className="friend-info">
+                      <h3>{friend.displayName || friend.username}</h3>
+                      <p>@{friend.username}</p>
+                      <WatchlistCountLine
+                        count={friend.watchlistCount}
+                        isLoading={isLoadingWatchlistCounts}
+                      />
+                    </div>
+                  </button>
+                );
+              })}
             </div>
 
             <div className="compare-actions">
@@ -143,6 +169,7 @@ export function FriendSelectionPage({
                     {selectedFriends.length !== 1 ? "s" : ""} selected
                   </p>
                   <button
+                    type="button"
                     onClick={onCompareWatchlists}
                     disabled={selectedFriends.length === 0}
                     className="btn btn-primary"

--- a/src/components/ResultsPage.tsx
+++ b/src/components/ResultsPage.tsx
@@ -25,6 +25,120 @@ import type { ResultsPageProps } from "../types";
 import { useMemo, useState, useEffect } from "react";
 import getGenreClassSlug from "../utils/genreClassMap";
 
+// Decode HTML entities and numeric references in server-supplied titles.
+// This is defensive: if a scraped title slips through with fragments like
+// "#039;s" or double-escaped "&amp;#039;s", we'll normalize it for display.
+function decodeHtmlEntities(input: string): string {
+  if (!input) return input;
+  // Basic named entities map
+  const map: Record<string, string> = {
+    "&amp;": "&",
+    "&lt;": "<",
+    "&gt;": ">",
+    "&quot;": '"',
+    "&apos;": "'",
+    "&#039;": "'",
+  };
+  let s = input;
+  // 1) Resolve double-escaped numeric entities like &amp;#039; first
+  s = s.replace(/&amp;#x?0*27;?/gi, "'");
+  s = s.replace(/&amp;#0*39;?/gi, "'");
+  // 2) Replace named entities next (e.g., &amp; -> &), which enables numeric decoding
+  s = s.replace(/&[a-zA-Z]+;/g, (ent) => map[ent] || ent);
+  // 3) Decode proper numeric references (these include the & and ;)
+
+  s = s.replace(/&#x([0-9A-Fa-f]+);/g, (_, hex) =>
+    String.fromCodePoint(Number.parseInt(hex, 16))
+  );
+  s = s.replace(/&#(\d+);/g, (_, dec) =>
+    String.fromCodePoint(Number.parseInt(dec, 10))
+  );
+  // 4) Handle stray fragments that lack the leading & (do NOT touch ones that have it)
+  // Use a leading char capture to avoid swallowing the character before '#'
+  s = s.replace(/(^|[^&])#x?0*27;?/gi, (_, pre: string) => pre + "'");
+  s = s.replace(/(^|[^&])#0*39;?/g, (_, pre: string) => pre + "'");
+
+  // Normalize common curly apostrophes to straight
+  s = s.replace(/[‘’]/g, "'");
+  // Remove ampersands that are part of broken numeric entity fragments
+  // (e.g. "& #039;" or "&amp; #039;") while preserving meaningful
+  // ampersands like "Tom & Jerry". Only strip the '&' when followed
+  // optionally by 'amp;' and then a '#'.
+  s = s.replace(/&(?:amp;)?\s*(?=#)/gi, "");
+  // Remove spaces that appear before apostrophes ("World 's" -> "World's").
+  // Anchored on (^|\S) so the whitespace run can only match from its start,
+  // which keeps the regex linear (sonar typescript:S8786).
+  s = s.replace(/(^|\S)\s+'+/g, "$1'");
+  // Fix cases like "World&'s" where a stray ampersand precedes an apostrophe
+  // Remove '&' only when immediately before optional spaces and one or more quotes
+  s = s.replace(/&(?=\s*'+)/g, "");
+  s = s.replace(/\s+/g, " ").trim();
+  return s;
+}
+
+// Truncate long genre labels to keep badges tidy (CSS may further constrain)
+function truncateLabel(s: string, max = 18): string {
+  if (!s) return s;
+  return s.length > max ? s.slice(0, max - 1).trimEnd() + "…" : s;
+}
+
+// Deduplicate genres by slug; prefer the first encountered label
+function dedupeGenres(raw: string[]): Array<{ slug: string; label: string }> {
+  const seen = new Set<string>();
+  const unique: Array<{ slug: string; label: string }> = [];
+  for (const g of raw) {
+    const slug = getGenreClassSlug(g);
+    if (!slug) continue;
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    unique.push({ slug, label: g });
+    if (unique.length >= 6) break; // soft cap to limit DOM
+  }
+  return unique;
+}
+
+// Genre badge row, extracted to keep JSX nesting shallow (sonar typescript:S2004)
+function GenreBadges({
+  movieId,
+  genres,
+  selectedGenres,
+  onToggle,
+}: Readonly<{
+  movieId: number;
+  genres: string[];
+  selectedGenres: string[];
+  onToggle: (slug: string, label: string) => void;
+}>) {
+  const unique = dedupeGenres(genres);
+  return (
+    <div className="movie-genre-badges">
+      {unique.slice(0, 3).map(({ slug, label }) => {
+        const isSelected =
+          selectedGenres.includes(slug) || selectedGenres.includes(label);
+        const className = `genre-badge genre-${slug} ${
+          isSelected ? "selected" : ""
+        }`;
+        return (
+          <button
+            key={`${movieId}-${slug}`}
+            type="button"
+            className={className}
+            title={label}
+            aria-label={`${label} genre${isSelected ? " (selected)" : ""}`}
+            aria-pressed={isSelected ? "true" : "false"}
+            onClick={(e) => {
+              e.preventDefault();
+              onToggle(slug, label);
+            }}
+          >
+            {truncateLabel(label)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export function ResultsPage({ movies, onBack }: Readonly<ResultsPageProps>) {
   // Store selected genres as slugs for stable matching across aliases (e.g.,
   // "Sci-Fi" and "Science Fiction" -> "scifi"). Maintain backward
@@ -38,7 +152,7 @@ export function ResultsPage({ movies, onBack }: Readonly<ResultsPageProps>) {
       // Parse the query string manually to avoid referencing global URLSearchParams
       const search = window.location.search || "";
       const qs = search.startsWith("?") ? search.slice(1) : search;
-      const match = qs.match(/(?:^|&)genres=([^&]+)/i);
+      const match = /(?:^|&)genres=([^&]+)/i.exec(qs);
       const raw = match ? match[1] : null;
       if (raw && raw.trim().length > 0) {
         const arr = raw
@@ -91,63 +205,23 @@ export function ResultsPage({ movies, onBack }: Readonly<ResultsPageProps>) {
       return false;
     });
   }, [movies, selectedGenres]);
-  // Decode HTML entities and numeric references in server-supplied titles.
-  // This is defensive: if a scraped title slips through with fragments like
-  // "#039;s" or double-escaped "&amp;#039;s", we'll normalize it for display.
-  function decodeHtmlEntities(input: string): string {
-    if (!input) return input;
-    // Basic named entities map
-    const map: Record<string, string> = {
-      "&amp;": "&",
-      "&lt;": "<",
-      "&gt;": ">",
-      "&quot;": '"',
-      "&apos;": "'",
-      "&#039;": "'",
-    };
-    let s = input;
-    // 1) Resolve double-escaped numeric entities like &amp;#039; first
-    s = s.replace(/&amp;#x?0*27;?/gi, "'");
-    s = s.replace(/&amp;#0*39;?/gi, "'");
-    // 2) Replace named entities next (e.g., &amp; -> &), which enables numeric decoding
-    s = s.replace(/&[a-zA-Z]+;/g, (ent) => map[ent] || ent);
-    // 3) Decode proper numeric references (these include the & and ;)
 
-    s = s.replace(/&#x([0-9A-Fa-f]+);/g, (_, hex) =>
-      String.fromCharCode(parseInt(hex, 16))
-    );
-    s = s.replace(/&#(\d+);/g, (_, dec) =>
-      String.fromCharCode(parseInt(dec, 10))
-    );
-    // 4) Handle stray fragments that lack the leading & (do NOT touch ones that have it)
-    // Use a leading char capture to avoid swallowing the character before '#'
-    s = s.replace(/(^|[^&])#x?0*27;?/gi, (_, pre: string) => pre + "'");
-    s = s.replace(/(^|[^&])#0*39;?/g, (_, pre: string) => pre + "'");
+  const toggleGenre = (slug: string, label: string) => {
+    setSelectedGenres((s) => {
+      const hasSlug = s.includes(slug);
+      const hasLabel = s.includes(label);
+      if (hasSlug || hasLabel) {
+        return s.filter((x) => x !== slug && x !== label);
+      }
+      return [...s, slug];
+    });
+  };
 
-    // Normalize common curly apostrophes to straight
-    s = s.replace(/[\u2018\u2019]/g, "'");
-    // Remove ampersands that are part of broken numeric entity fragments
-    // (e.g. "& #039;" or "&amp; #039;") while preserving meaningful
-    // ampersands like "Tom & Jerry". Only strip the '&' when followed
-    // optionally by 'amp;' and then a '#'.
-    s = s.replace(/&(?:amp;)?\s*(?=#)/gi, "");
-    // Remove spaces that appear before apostrophes ("World 's" -> "World's")
-    s = s.replace(/\s+'+/g, "'");
-    // Fix cases like "World&'s" where a stray ampersand precedes an apostrophe
-    // Remove '&' only when immediately before optional spaces and one or more quotes
-    s = s.replace(/&(?=\s*'+)/g, "");
-    s = s.replace(/\s+/g, " ").trim();
-    return s;
-  }
-  // Truncate long genre labels to keep badges tidy (CSS may further constrain)
-  function truncateLabel(s: string, max = 18): string {
-    if (!s) return s;
-    return s.length > max ? s.slice(0, max - 1).trimEnd() + "…" : s;
-  }
   return (
     <section className="page results-page dynamic-cards">
       <div className="page-header">
         <button
+          type="button"
           onClick={onBack}
           className="btn btn-secondary btn-icon header-back-btn"
           aria-label="Back to setup"
@@ -173,6 +247,7 @@ export function ResultsPage({ movies, onBack }: Readonly<ResultsPageProps>) {
         <div className="header-controls">
           {selectedGenres.length > 0 && (
             <button
+              type="button"
               className="btn btn-icon btn-secondary"
               onClick={(e) => {
                 e.preventDefault();
@@ -213,6 +288,7 @@ export function ResultsPage({ movies, onBack }: Readonly<ResultsPageProps>) {
                   see all common movies.
                 </p>
                 <button
+                  type="button"
                   className="btn btn-secondary"
                   onClick={(e) => {
                     e.preventDefault();
@@ -252,9 +328,7 @@ export function ResultsPage({ movies, onBack }: Readonly<ResultsPageProps>) {
                       }
                       {(() => {
                         const p = movie.poster_path as
-                          | string
-                          | null
-                          | undefined;
+                          string | null | undefined;
                         let posterUrl: string | null = null;
                         if (p && typeof p === "string") {
                           const trimmed = p.trim();
@@ -300,62 +374,12 @@ export function ResultsPage({ movies, onBack }: Readonly<ResultsPageProps>) {
                           </h3>
 
                           {movie.genres && movie.genres.length > 0 && (
-                            <div className="movie-genre-badges">
-                              {(() => {
-                                const raw = (movie.genres || []) as string[];
-                                // Deduplicate by slug; prefer the first encountered label
-                                const seen = new Set<string>();
-                                const unique: Array<{
-                                  slug: string;
-                                  label: string;
-                                }> = [];
-                                for (const g of raw) {
-                                  const slug = getGenreClassSlug(g);
-                                  if (!slug) continue;
-                                  if (seen.has(slug)) continue;
-                                  seen.add(slug);
-                                  unique.push({ slug, label: g });
-                                  if (unique.length >= 6) break; // soft cap to limit DOM
-                                }
-                                return unique
-                                  .slice(0, 3)
-                                  .map(({ slug, label }) => {
-                                    const isSelected =
-                                      selectedGenres.includes(slug) ||
-                                      selectedGenres.includes(label);
-                                    const className = `genre-badge genre-${slug} ${
-                                      isSelected ? "selected" : ""
-                                    }`;
-                                    return (
-                                      <button
-                                        key={`${movie.id}-${slug}`}
-                                        type="button"
-                                        className={className}
-                                        title={label}
-                                        aria-label={`${label} genre${isSelected ? " (selected)" : ""}`}
-                                        aria-pressed={
-                                          isSelected ? "true" : "false"
-                                        }
-                                        onClick={(e) => {
-                                          e.preventDefault();
-                                          setSelectedGenres((s) => {
-                                            const hasSlug = s.includes(slug);
-                                            const hasLabel = s.includes(label);
-                                            if (hasSlug || hasLabel) {
-                                              return s.filter(
-                                                (x) => x !== slug && x !== label
-                                              );
-                                            }
-                                            return [...s, slug];
-                                          });
-                                        }}
-                                      >
-                                        {truncateLabel(label)}
-                                      </button>
-                                    );
-                                  });
-                              })()}
-                            </div>
+                            <GenreBadges
+                              movieId={movie.id}
+                              genres={(movie.genres || []) as string[]}
+                              selectedGenres={selectedGenres}
+                              onToggle={toggleGenre}
+                            />
                           )}
                         </div>
 
@@ -394,7 +418,8 @@ export function ResultsPage({ movies, onBack }: Readonly<ResultsPageProps>) {
                               {movie.friendList.map((friendName: string) => {
                                 // Use stable color class by hashing username to index (same algorithm as getUserColors)
                                 const hash = Array.from(friendName).reduce(
-                                  (h, ch) => ch.charCodeAt(0) + ((h << 5) - h),
+                                  (h, ch) =>
+                                    (ch.codePointAt(0) ?? 0) + ((h << 5) - h),
                                   0
                                 );
                                 const idx = Math.abs(hash) % 20;

--- a/src/components/ResultsPage.tsx
+++ b/src/components/ResultsPage.tsx
@@ -25,6 +25,16 @@ import type { ResultsPageProps } from "../types";
 import { useMemo, useState, useEffect } from "react";
 import getGenreClassSlug from "../utils/genreClassMap";
 
+// Convert a numeric code point to its character, tolerating out-of-range or
+// non-numeric input. String.fromCodePoint throws a RangeError for values
+// outside 0..0x10FFFF (or NaN), so fall back to the original matched text.
+function codePointToChar(codePoint: number, original: string): string {
+  if (Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff) {
+    return String.fromCodePoint(codePoint);
+  }
+  return original;
+}
+
 // Decode HTML entities and numeric references in server-supplied titles.
 // This is defensive: if a scraped title slips through with fragments like
 // "#039;s" or double-escaped "&amp;#039;s", we'll normalize it for display.
@@ -47,11 +57,11 @@ function decodeHtmlEntities(input: string): string {
   s = s.replace(/&[a-zA-Z]+;/g, (ent) => map[ent] || ent);
   // 3) Decode proper numeric references (these include the & and ;)
 
-  s = s.replace(/&#x([0-9A-Fa-f]+);/g, (_, hex) =>
-    String.fromCodePoint(Number.parseInt(hex, 16))
+  s = s.replace(/&#x([0-9A-Fa-f]+);/g, (m, hex) =>
+    codePointToChar(Number.parseInt(hex, 16), m)
   );
-  s = s.replace(/&#(\d+);/g, (_, dec) =>
-    String.fromCodePoint(Number.parseInt(dec, 10))
+  s = s.replace(/&#(\d+);/g, (m, dec) =>
+    codePointToChar(Number.parseInt(dec, 10), m)
   );
   // 4) Handle stray fragments that lack the leading & (do NOT touch ones that have it)
   // Use a leading char capture to avoid swallowing the character before '#'

--- a/src/components/SetupPage.tsx
+++ b/src/components/SetupPage.tsx
@@ -29,7 +29,7 @@ export function SetupPage({
   isLoadingFriends,
   friendsLoadingProgress,
   error,
-}: SetupPageProps) {
+}: Readonly<SetupPageProps>) {
   return (
     <section className="page setup-page">
       <div className="page-content">
@@ -70,6 +70,7 @@ export function SetupPage({
           )}
 
           <button
+            type="button"
             onClick={onSetup}
             disabled={isLoading || !username.trim()}
             className="btn btn-primary"

--- a/src/services/cacheService.ts
+++ b/src/services/cacheService.ts
@@ -63,8 +63,8 @@ interface WatchlistCountEntry {
 }
 
 export class WebCacheService {
-  private static CACHE_KEY = "boxdbuddy_cache";
-  private static CACHE_VERSION = "1.0.0";
+  private static readonly CACHE_KEY = "boxdbuddy_cache";
+  private static readonly CACHE_VERSION = "1.0.0";
 
   static getCache(): UserCache {
     try {
@@ -99,7 +99,7 @@ export class WebCacheService {
     const cache = this.getCache();
     const entry = cache.friends;
 
-    if (!entry || entry.version !== this.CACHE_VERSION) {
+    if (entry?.version !== this.CACHE_VERSION) {
       return null;
     }
 
@@ -122,7 +122,7 @@ export class WebCacheService {
     const cache = this.getCache();
     const entry = cache.watchlists?.[username];
 
-    if (!entry || entry.version !== this.CACHE_VERSION) {
+    if (entry?.version !== this.CACHE_VERSION) {
       return null;
     }
 
@@ -133,7 +133,7 @@ export class WebCacheService {
 
   static setWatchlist(username: string, movies: MovieData[]): void {
     const cache = this.getCache();
-    if (!cache.watchlists) cache.watchlists = {};
+    cache.watchlists ??= {};
 
     cache.watchlists[username] = {
       data: movies,
@@ -155,11 +155,11 @@ export class WebCacheService {
   }
 
   static getComparison(usernames: string[]): ComparisonResult | null {
-    const key = usernames.sort().join(":");
+    const key = [...usernames].sort((a, b) => a.localeCompare(b)).join(":");
     const cache = this.getCache();
     const entry = cache.comparisons?.[key];
 
-    if (!entry || entry.version !== this.CACHE_VERSION) {
+    if (entry?.version !== this.CACHE_VERSION) {
       return null;
     }
 
@@ -169,9 +169,9 @@ export class WebCacheService {
   }
 
   static setComparison(usernames: string[], result: ComparisonResult): void {
-    const key = usernames.sort().join(":");
+    const key = [...usernames].sort((a, b) => a.localeCompare(b)).join(":");
     const cache = this.getCache();
-    if (!cache.comparisons) cache.comparisons = {};
+    cache.comparisons ??= {};
 
     cache.comparisons[key] = {
       data: result,
@@ -216,7 +216,7 @@ export class WebCacheService {
     entry: WatchlistCountEntry
   ): void {
     const cache = this.getCache();
-    if (!cache.watchlistCounts) cache.watchlistCounts = {};
+    cache.watchlistCounts ??= {};
 
     cache.watchlistCounts[username] = {
       ...entry,
@@ -229,7 +229,7 @@ export class WebCacheService {
     const cache = this.getCache();
     const entry = cache.watchlistCounts?.[username];
 
-    if (!entry || entry.version !== this.CACHE_VERSION) {
+    if (entry?.version !== this.CACHE_VERSION) {
       incrementMetric("cache.miss");
       return null;
     }

--- a/src/services/cloudflareBackend.ts
+++ b/src/services/cloudflareBackend.ts
@@ -48,7 +48,7 @@ interface ComparisonResult {
 }
 
 export class CloudflareBackend {
-  private static BASE_URL = import.meta.env.PROD
+  private static readonly BASE_URL = import.meta.env.PROD
     ? "https://boxdbud.io/api"
     : "http://localhost:8788/api";
 

--- a/src/services/watchlistFetcher.ts
+++ b/src/services/watchlistFetcher.ts
@@ -28,7 +28,6 @@ import { FEATURE_WATCHLIST_FETCHER } from "../config/featureFlags";
 
 // Add global declarations for web environment
 declare const fetch: typeof globalThis.fetch;
-declare const navigator: typeof globalThis.navigator;
 
 // Minimal type for objects that expose add/remove event listener methods
 interface WindowEventTarget {
@@ -227,7 +226,7 @@ class WatchlistFetcher {
 
     try {
       // Check if we're offline
-      if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      if (globalThis.navigator?.onLine === false) {
         logger.debug("Offline detected, queuing usernames for later");
         this.offlineQueue.push(...usernames);
         return;
@@ -313,7 +312,7 @@ class WatchlistFetcher {
         }
       } else if (typeof newCount === "number") {
         // Check if count actually changed
-        const countChanged = !currentEntry || currentEntry.count !== newCount;
+        const countChanged = currentEntry?.count !== newCount;
 
         if (countChanged) {
           // Count changed - update everything

--- a/src/utils/genreClassMap.ts
+++ b/src/utils/genreClassMap.ts
@@ -98,10 +98,12 @@ export function getGenreClassSlug(genre: string): string {
   const key = genre.toLowerCase().trim();
   if (MAP[key]) return MAP[key];
   // Fallback slugify: letters/numbers only, collapse repeated separators
+  // After collapsing runs above, at most one leading/trailing dash remains,
+  // so a single-dash trim is equivalent and linear (sonar typescript:S8786)
   const slug = key
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replace(/^-|-$/g, "");
   return slug || "default";
 }
 


### PR DESCRIPTION
## Summary

Resolves all remaining SonarCloud issues in `src/**` (TS/TSX) and `scripts/*.{js,cjs,mjs}` (~53 issues: 3 Critical, ~20 Major, ~30 Minor).

### Critical
- **S2004** (functions nested >4 deep) — `ResultsPage`: hoisted `decodeHtmlEntities`/`truncateLabel` to module scope (also fixes both **S7721**) and extracted a `GenreBadges` component + `toggleGenre` handler, flattening the badge-rendering JSX
- **S2871 + S4043** (unreliable in-place sort) — `WebCacheService.get/setComparison` now build keys with `[...usernames].sort((a, b) => a.localeCompare(b))` — no argument mutation, deterministic ordering. Note: cache keys for multi-user comparisons may change once, causing a one-time cache miss

### Major
- **S9011**: explicit `type="button"` on all flagged buttons (App, SetupPage, FriendSelectionPage, ResultsPage)
- **S6848/S1082**: friend cards converted from clickable `<div>`s to native `<button>` elements — keyboard operable, `aria-pressed` state; inline `font/color: inherit` preserves the existing `.friend-card` styling
- **S3358**: nested ternaries extracted into a `WatchlistCountLine` helper component
- **S2933**: `readonly` static members (`WebCacheService`, `CloudflareBackend`)
- **S8786** (super-linear regexes): linear rewrites in `decodeHtmlEntities` (whitespace-before-apostrophe collapse anchored on `(^|\S)`), `genreClassMap` slug trim, and `check-supported-version.cjs` table normalization (split/trim instead of `/\s*\|\s*/g`)

### Minor
`Readonly<Props>` on components (S6759), optional chaining incl. `globalThis.navigator?.onLine` (S6582/S7741), `??=` (S6606), `Number.parseInt` with radix (S7773), `String.fromCodePoint`/`codePointAt` (S7758), `RegExp.exec` (S6594), `toHaveLength` in tests (S5906), `node:fs`/`node:path` prefixes (S7772), top-level flow instead of async IIFE in `sync-favicon.mjs` (S7785).

## Testing

- `npm run lint` — 0 problems ✅
- `tsc --noEmit` ✅
- `npm run test` — 117/117 ✅
- `npm run build` ✅

Part 4 of 4 SonarCloud cleanup PRs — together with #316, #317, #318 this addresses all 222 open SonarCloud issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)